### PR TITLE
Improve performance of `Similarity::calculateVectors`

### DIFF
--- a/include/Statistics/Similarity.h
+++ b/include/Statistics/Similarity.h
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <iomanip>
 #include <math.h>
+#include <vector>
 
 // Forward declaration
 class Alignment;
@@ -73,6 +74,12 @@ namespace statistics {
 
         /** \brief Counter of how many other instances share the same information */
         int * refCounter;
+
+        /** \brief Temporary buffer to store a column from the parent alignment. */
+        std::string column;
+
+        /** \brief Temporary buffer to store which column characters are gaps or indeterminate. */
+        std::vector<char> colgap;
 
     public:
         /** \brief Computes the matrix identity between alignment's columns. */

--- a/include/Statistics/similarityMatrix.h
+++ b/include/Statistics/similarityMatrix.h
@@ -41,7 +41,7 @@
 
 
 namespace statistics {
-/** 
+/**
  * \brief Class that contains information of similarity matrices.\n
  * These are used to calculate the similarity between residues on the same column.
  * <br>
@@ -49,6 +49,7 @@ namespace statistics {
  */
     class similarityMatrix {
 
+    public:
         int *vhash;
         float **simMat;
         float **distMat;

--- a/source/Statistics/Similarity.cpp
+++ b/source/Statistics/Similarity.cpp
@@ -209,6 +209,10 @@ namespace statistics {
         //      similarity
         float gapThreshold = 0.8F * alig->numberOfResidues;
 
+        // Cache pointers to matrix rows to avoid dereferencing in inner loops
+        float* identityRow;
+        float* distRow;
+
         // For each column calculate the Q value and the MD value using an equation
         for (i = 0; i < alig->originalNumberOfResidues; i++) {
             // Set MDK for columns with gaps values bigger or equal to 0.8F
@@ -250,6 +254,10 @@ namespace statistics {
                 chA = column[j];
                 numA = simMatrix->vhash[chA - 'A'];
 
+                // Store address of matrix rows
+                distRow = simMatrix->distMat[numA];
+                identityRow = matrixIdentity[j];
+
                 for (k = j + 1; k < alig->originalNumberOfSequences; k++) {
                     // We don't compute the distance if the second element is
                     //      a indeterminate (XN) or a gap (-) element
@@ -267,8 +275,8 @@ namespace statistics {
 
                     // We use the identity value for the two pairs and
                     //      its distance based on similarity matrix's value.
-                    num += matrixIdentity[j][k] * simMatrix->distMat[numA][numB];
-                    den += matrixIdentity[j][k];
+                    num += identityRow[k] * distRow[numB];
+                    den += identityRow[k];
                 }
             }
 

--- a/source/Statistics/Similarity.cpp
+++ b/source/Statistics/Similarity.cpp
@@ -36,6 +36,8 @@
 #include "utils.h"
 #include "omp.h"
 
+#include <vector>
+
 namespace statistics {
 
     Similarity::Similarity(Alignment *parentAlignment) {
@@ -52,6 +54,10 @@ namespace statistics {
         simMatrix = nullptr;
 
         refCounter = new int(1);
+
+        // Initialize temporary vectors
+        column = std::string(alig->originalNumberOfSequences, 0);
+        colgap = std::vector<char>(alig->originalNumberOfSequences, 0);
     }
 
     Similarity::Similarity(Alignment *parentAlignment,
@@ -71,6 +77,10 @@ namespace statistics {
 
         refCounter = mold->refCounter;
         (*refCounter)++;
+
+        // copy temporary vectors
+        column = std::string(mold->column);
+        colgap = std::vector<char>(mold->colgap);
     }
 
     Similarity::~Similarity() {
@@ -625,4 +635,3 @@ namespace statistics {
     }
 
 }
-


### PR DESCRIPTION
Hi there!

While working on [althonos/pytrimal](https://github.com/althonos/pytrimal) I did some thorough profiling of the code, and I identified some critical sections that could be improved. In particular, I noticed that the code in `Similarity::calculateVectors` was sub-optimal, because it was repeatedly calling `similarityMatrix::getDistance` with the same sequence characters, and the check for invalid/incorrect symbols seems to have a high performance impact. 

To fix this, I added two buffers to store column data; the first one for the sequence itself, storing uppercase column characters to reduce the number of `utils::toUpper` calls; the other one to store the indices of gapped/indeterminate characters. The sequence characters for a column are checked once when the column is copied; after that, the distance matrix is indexed directly, without checking character ranges.

I used `valgrind` to count cycles on a run of trimAl in strict mode on `example.073.AA.strNOG.ENOG411BFCW.fasta`, here are the results in number of cycles:

Object | cycles (before PR) | cycles (after PR)
---|---|---
`Similarity::calculateVectors` (self) | 3,132,810,840 | 1,652,854574
`Similarity::calculateVectors` (incl) | 8,281,641,990 | 3,240,879,580
`trimal` (total) | 13,504,155,928 | 8,463,690,891

