### PR TITLE
Move identity and overlap computation into dedicated `statistics` classes

### DIFF
--- a/include/Alignment/Alignment.h
+++ b/include/Alignment/Alignment.h
@@ -85,9 +85,6 @@ public:
 
     std::string alignmentInfo;
 
-    /* Sequence Identities */
-    float **identities = nullptr;
-
     /* Sequence Overlaps */
     float **overlaps = nullptr;
 

--- a/include/Alignment/Alignment.h
+++ b/include/Alignment/Alignment.h
@@ -85,9 +85,6 @@ public:
 
     std::string alignmentInfo;
 
-    /* Sequence Overlaps */
-    float **overlaps = nullptr;
-
     /* New Info */
     int *saveResidues = nullptr;
     int *saveSequences = nullptr;

--- a/include/Cleaner.h
+++ b/include/Cleaner.h
@@ -422,19 +422,6 @@ public:
     void setBoundaries(int *boundaries);
 
      /**
-      \brief Method to calculate identities between the sequences from the alignment.\n
-      See Alignment::identities
-      */
-    void calculateSeqIdentity();
-
-     /**
-      \warning Not In Use
-      \brief Method that makes a raw approximation of sequence identity computation.\n
-      \note Designed for reducing comparisons for huge alignments.
-      */
-    void calculateRelaxedSeqIdentity();
-
-     /**
         \brief Method to assign sequences to clusters.\n
         Clusters are calculated following this flow:
           - Select the longest sequence and

--- a/include/Cleaner.h
+++ b/include/Cleaner.h
@@ -261,19 +261,6 @@ public:
     Alignment *cleanCompareFile(float cutpoint, float baseLine, float *vectValues, bool complementary);
 
      /**
-      \brief Method to compute the overlap values.\n
-        See Alignment::overlaps
-      \param overlap
-       Overlap threshold.
-      \param[out] spuriousVector
-       Pointer to the spuriousVector to fill.
-      \return   <b> True </b> if the calculation went ok.\n
-                <b> False </b> otherwise.\n
-      This should happen only if you pass a null pointer instead of a spuriousVector.
-*/
-    bool calculateSpuriousVector(float overlap, float *spuriousVector);
-
-     /**
       \brief Method to remove sequences missaligned
        with the rest of sequences in the alignment.\n
        For each residue in the sequence, it tests it's similarity.

--- a/include/Statistics/Identity.h
+++ b/include/Statistics/Identity.h
@@ -1,0 +1,79 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde M.             (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef STATISTICS_IDENTITY_H
+#define STATISTICS_IDENTITY_H
+
+class Alignment;
+
+namespace statistics {
+
+    /**
+     * \brief Class to handle the calculation relative to identity.\n
+     * Computation was previously done by Cleaner directly on Alignment 
+     * objects, but was moved to a dedicated class for consistency with
+     * other statistics.
+    */
+    class Identity {
+    public:
+        Identity(Alignment *parentAlignment, Identity *mold);
+
+        Alignment *alig;
+
+        /** \brief Identity between sequences */
+        float **identities = nullptr;
+
+        /** \brief Counter of how many other instances share the same information */
+        int * refCounter;
+
+    public:
+        /** \brief Constructor without any parameters */
+        explicit Identity(Alignment* parentAlignment);
+
+        /** \brief Destructor */
+        ~Identity();
+
+        /**
+        \brief Method to calculate identities between the sequences from the alignment.\n
+        */
+        void calculateSeqIdentity();
+
+        /**
+        \warning Not In Use
+        \brief Method that makes a raw approximation of sequence identity computation.\n
+        \note Designed for reducing comparisons for huge alignments.
+        */
+        void calculateRelaxedSeqIdentity();
+    };
+}
+
+#endif

--- a/include/Statistics/Manager.h
+++ b/include/Statistics/Manager.h
@@ -130,6 +130,12 @@ namespace statistics {
         bool calculateSeqOverlap();
 
         /**
+         * \brief Method to handle spurious vector calculation\n
+         * It checks if the #overlap submodule has been created, otherwise, creates it
+         * */
+        bool calculateSpuriousVector(float overlapColumn, float *spuriousVector);
+
+        /**
          * \brief Wrapper to Statistics::Similarity::printConservationAcl()\n
          * It calls to calculateConservationStats() to make sure the information is available before reporting the requested values
          * */

--- a/include/Statistics/Manager.h
+++ b/include/Statistics/Manager.h
@@ -45,6 +45,8 @@ namespace statistics {
 
     class Consistency;
 
+    class Identity;
+
     /**
      * \brief Class to handle the interaction with Alignment and statistics objects.\n
      * It serves as a wrapper or intermediate between the alignment and each specific stat.\n
@@ -65,6 +67,10 @@ namespace statistics {
          * \brief Consistency submodule
          * */
         Consistency *consistency = nullptr;
+        /**
+         * \brief Consistency submodule
+         * */
+        Identity *identity = nullptr;
 
         /**
          * \brief SimilarityMatrix used by Similarity
@@ -90,6 +96,12 @@ namespace statistics {
          * It checks if the #gaps submodule has been created, otherwise, creates it
          * */
         bool calculateGapStats();
+
+        /**
+         * \brief Method to handle alignment identity calculation\n
+         * It checks if the #identity submodule has been created, otherwise, creates it
+         * */
+        bool calculateSeqIdentity();
 
         /**
          * \brief Wrapper to Statistics::Gaps::printGapsColumns()\n

--- a/include/Statistics/Manager.h
+++ b/include/Statistics/Manager.h
@@ -40,12 +40,10 @@ class Alignment;
 namespace statistics {
 // Forward declarations
     class Gaps;
-
     class Similarity;
-
     class Consistency;
-
     class Identity;
+    class Overlap;
 
     /**
      * \brief Class to handle the interaction with Alignment and statistics objects.\n
@@ -71,6 +69,10 @@ namespace statistics {
          * \brief Consistency submodule
          * */
         Identity *identity = nullptr;
+        /**
+         * \brief Overlap submodule
+         */
+        Overlap *overlap = nullptr;
 
         /**
          * \brief SimilarityMatrix used by Similarity
@@ -120,6 +122,12 @@ namespace statistics {
          * It checks if the #similarity submodule has been created, otherwise, creates it
          * */
         bool calculateConservationStats();
+
+        /**
+         * \brief Method to handle overlap stat calculation\n
+         * It checks if the #overlap submodule has been created, otherwise, creates it
+         * */
+        bool calculateSeqOverlap();
 
         /**
          * \brief Wrapper to Statistics::Similarity::printConservationAcl()\n

--- a/include/Statistics/Overlap.h
+++ b/include/Statistics/Overlap.h
@@ -49,7 +49,7 @@ namespace statistics {
 
         Alignment *alig;
 
-        /** \brief Identity between sequences */
+        /** \brief Overlap between sequences */
         int **overlaps = nullptr;
 
         /** \brief Counter of how many other instances share the same information */

--- a/include/Statistics/Overlap.h
+++ b/include/Statistics/Overlap.h
@@ -50,7 +50,7 @@ namespace statistics {
         Alignment *alig;
 
         /** \brief Overlap between sequences */
-        int **overlaps = nullptr;
+        float **overlaps = nullptr;
 
         /** \brief Counter of how many other instances share the same information */
         int * refCounter;

--- a/include/Statistics/Overlap.h
+++ b/include/Statistics/Overlap.h
@@ -1,0 +1,84 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde M.             (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef STATISTICS_OVERLAP_H
+#define STATISTICS_OVERLAP_H
+
+class Alignment;
+
+namespace statistics {
+
+    /**
+     * \brief Class to handle the calculation relative to overlap.\n
+     * Computation was previously done by Cleaner directly on Alignment 
+     * objects, but was moved to a dedicated class for consistency with
+     * other statistics.
+    */
+    class Overlap {
+    public:
+        Overlap(Alignment *parentAlignment, Overlap *mold);
+
+        Alignment *alig;
+
+        /** \brief Identity between sequences */
+        int **overlaps = nullptr;
+
+        /** \brief Counter of how many other instances share the same information */
+        int * refCounter;
+
+    public:
+        /** \brief Constructor without any parameters */
+        explicit Overlap(Alignment* parentAlignment);
+
+        /** \brief Destructor */
+        ~Overlap();
+
+        /**
+        \brief Method to calculate overlap between the sequences from the alignment.\n
+        */
+        void calculateSeqOverlap();
+
+        /**
+        \brief Method to compute the overlap values.\n
+        \param overlap
+        Overlap threshold.
+        \param[out] spuriousVector
+        Pointer to the spuriousVector to fill.
+        \return   <b> True </b> if the calculation went ok.\n
+                    <b> False </b> otherwise.\n
+        This should happen only if you pass a null pointer instead of a spuriousVector.
+        */
+        bool calculateSpuriousVector(float overlapColumn, float *spuriousVector);
+    };
+}
+
+#endif

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -16,6 +16,7 @@ set(statisticFiles
         source/Statistics/Gaps.cpp
         source/Statistics/Manager.cpp
         source/Statistics/Similarity.cpp
+        source/Statistics/Identity.cpp
         source/Statistics/Consistency.cpp)
 
 set(reportSystemFiles

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -17,6 +17,7 @@ set(statisticFiles
         source/Statistics/Manager.cpp
         source/Statistics/Similarity.cpp
         source/Statistics/Identity.cpp
+        source/Statistics/Overlap.cpp
         source/Statistics/Consistency.cpp)
 
 set(reportSystemFiles

--- a/source/Alignment/Alignment.cpp
+++ b/source/Alignment/Alignment.cpp
@@ -27,14 +27,7 @@
 
 ***************************************************************************** */
 #include "Statistics/Similarity.h"
-#include "Statistics/Consistency.h"
-#include "InternalBenchmarker.h"
-#include "Statistics/Manager.h"
-#include "Alignment/sequencesMatrix.h"
-#include "reportsystem.h"
-#include "Cleaner.h"
-#include "utils.h"
-#include "Statistics/Similarity.h"
+#include "Statistics/Identity.h"
 #include "Statistics/Consistency.h"
 #include "InternalBenchmarker.h"
 #include "Statistics/Manager.h"
@@ -75,7 +68,6 @@ Alignment::Alignment() {
 
     // Information computed from Alignment
     SequencesMatrix = nullptr;
-    identities = nullptr;
 
     // Pointer that helps to keep a count on how many items use the same information
     //  Upon destruction of the object, the counter is decreased, and, 
@@ -104,7 +96,6 @@ Alignment::Alignment(Alignment &originalAlignment) {
         originalNumberOfResidues = originalAlignment.originalNumberOfResidues;
         originalNumberOfSequences = originalAlignment.originalNumberOfSequences;
 
-        identities = nullptr;
         SequencesMatrix = nullptr;
 
         // Copy save(Sequences|Residues) vector to keep information of previous
@@ -139,12 +130,6 @@ Alignment::~Alignment() {
     delete[] saveResidues;
 
     delete[] saveSequences;
-
-    if (identities != nullptr) {
-        for (int i = 0; i < numberOfSequences; i++)
-            delete[] identities[i];
-        delete[] identities;
-    }
 
     delete SequencesMatrix;
 
@@ -922,8 +907,8 @@ void Alignment::printSeqIdentity() {
     float mx, avg, maxAvgSeq = 0, maxSeq = 0, avgSeq = 0, **maxs;
 
     // Ask for the sequence identities assesment
-    if (identities == nullptr)
-        Cleaning->calculateSeqIdentity();
+    Statistics->calculateSeqIdentity();
+    float** identities = Statistics->identity->identities;
 
     // For each sequence, we look for its most similar one
     maxs = new float *[originalNumberOfSequences];

--- a/source/Alignment/Alignment.cpp
+++ b/source/Alignment/Alignment.cpp
@@ -998,7 +998,7 @@ void Alignment::printSeqOverlap() {
 
     // Ask for the sequence identities assessment
     Statistics->calculateSeqOverlap();
-    int** overlaps = Statistics->overlap->overlaps;
+    float** overlaps = Statistics->overlap->overlaps;
 
     // For each sequence, we look for its most similar one 
     maxs = new float *[numberOfSequences];

--- a/source/Alignment/Alignment.cpp
+++ b/source/Alignment/Alignment.cpp
@@ -29,8 +29,9 @@
 #include "Statistics/Similarity.h"
 #include "Statistics/Identity.h"
 #include "Statistics/Consistency.h"
-#include "InternalBenchmarker.h"
 #include "Statistics/Manager.h"
+#include "Statistics/Overlap.h"
+#include "InternalBenchmarker.h"
 #include "Alignment/sequencesMatrix.h"
 #include "reportsystem.h"
 #include "Cleaner.h"
@@ -359,7 +360,7 @@ void Alignment::calculateRelaxedSeqIdentity() {
     }
 }
 */
-
+/*
 void Alignment::calculateSeqOverlap() {
     // Create a timer that will report times upon its destruction
     //	which means the end of the current scope.
@@ -397,6 +398,7 @@ void Alignment::calculateSeqOverlap() {
         }
     }
 }
+*/
 
 void Alignment::getSequences(string *Names) {
     // Create a timer that will report times upon its destruction
@@ -995,8 +997,8 @@ void Alignment::printSeqOverlap() {
     float mx, avg, maxAvgSeq = 0, maxSeq = 0, avgSeq = 0, **maxs;
 
     // Ask for the sequence identities assessment
-    if (overlaps == nullptr)
-        calculateSeqOverlap();
+    Statistics->calculateSeqOverlap();
+    int** overlaps = Statistics->overlap->overlaps;
 
     // For each sequence, we look for its most similar one 
     maxs = new float *[numberOfSequences];

--- a/source/Cleaner.cpp
+++ b/source/Cleaner.cpp
@@ -32,6 +32,7 @@
 #include "InternalBenchmarker.h"
 #include "Statistics/Manager.h"
 #include "Statistics/Gaps.h"
+#include "Statistics/Identity.h"
 #include "reportsystem.h"
 #include "Alignment/Alignment.h"
 #include "defines.h"
@@ -48,8 +49,8 @@ int Cleaner::selectMethod() {
     int i, j;
 
     // Ask for the sequence identities assesment
-    if (alig->identities == nullptr)
-        calculateSeqIdentity();
+    alig->Statistics->calculateSeqIdentity();
+    float **identities = alig->Statistics->identity->identities;
 
     // Once we have the identities among all possible
     // combinations between each pair of sequence. We
@@ -59,8 +60,8 @@ int Cleaner::selectMethod() {
     for (i = 0; i < alig->numberOfSequences; i++) {
         for (j = 0, mx = 0, avg = 0; j < alig->numberOfSequences; j++) {
             if (i != j) {
-                mx = mx < alig->identities[i][j] ? alig->identities[i][j] : mx;
-                avg += alig->identities[i][j];
+                mx = mx < identities[i][j] ? identities[i][j] : mx;
+                avg += identities[i][j];
             }
         }
         avgSeq += avg / (alig->numberOfSequences - 1);
@@ -930,7 +931,6 @@ bool Cleaner::calculateSpuriousVector(float overlap, float *spuriousVector) {
     return true;
 }
 
-
 Alignment *Cleaner::cleanSpuriousSeq(float overlapColumn, float minimumOverlap, bool complementary) {
     // Create a timer that will report times upon its destruction
     //	which means the end of the current scope.
@@ -1082,8 +1082,8 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
     else if (clusterNumber == 1) return 0;
 
     // Ask for the sequence identities assessment
-    if (alig->identities == nullptr)
-        calculateSeqIdentity();
+    alig->Statistics->calculateSeqIdentity();
+    float **identities = alig->Statistics->identity->identities;
 
     // Compute the maximum, the minimum and the average
     // identity values from the sequences
@@ -1093,17 +1093,17 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
         for (j = 0, max = 0, avg = 0, min = 1; j < i; j++) {
             if (alig->saveSequences[j] == -1) continue;
 
-            max = std::max(max, alig->identities[i][j]);
-            min = std::min(min, alig->identities[i][j]);
-            avg += alig->identities[i][j];
+            max = std::max(max, identities[i][j]);
+            min = std::min(min, identities[i][j]);
+            avg += identities[i][j];
         }
 
         for (j = i + 1; j < alig->numberOfSequences; j++) {
             if (alig->saveSequences[j] == -1) continue;
 
-            max = std::max(max, alig->identities[i][j]);
-            min = std::min(min, alig->identities[i][j]);
-            avg += alig->identities[i][j];
+            max = std::max(max, identities[i][j]);
+            min = std::min(min, identities[i][j]);
+            avg += identities[i][j];
         }
 
         startingPoint += avg / (alig->numberOfSequences - 1);
@@ -1143,7 +1143,7 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
         for (i = alig->numberOfSequences - 2; i >= 0; i--) {
 
             for (j = 0; j < clusterNum; j++)
-                if (alig->identities[seqs[i][1]][cluster[j]] > startingPoint)
+                if (identities[seqs[i][1]][cluster[j]] > startingPoint)
                     break;
 
             if (j == clusterNum) {
@@ -1431,97 +1431,6 @@ void Cleaner::removeAllGapsSeqsAndCols(bool seqs, bool cols) {
     }
 }
 
-void Cleaner::calculateSeqIdentity() {
-    // Create a timer that will report times upon its destruction
-    //	which means the end of the current scope.
-    StartTiming("void Cleaner::calculateSeqIdentity(void) ");
-
-    int i, j, k, hit, dst;
-    char indet;
-
-    // Depending on alignment type, indetermination symbol will be one or other
-    indet = (alig->getAlignmentType() & SequenceTypes::AA) ? 'X' : 'N';
-
-    // Create identities matrix to store identities scores
-    alig->identities = new float *[alig->originalNumberOfSequences];
-
-    // For each seq, compute its identity score against the others in the MSA
-    for (i = 0; i < alig->originalNumberOfSequences; i++) {
-        if (alig->saveSequences[i] == -1) continue;
-        alig->identities[i] = new float[alig->originalNumberOfSequences];
-
-        // It's a symmetric matrix, copy values that have been already computed
-        for (j = 0; j < i; j++) {
-            if (alig->saveSequences[j] == -1) continue;
-            alig->identities[i][j] = alig->identities[j][i];
-        }
-        alig->identities[i][i] = 0;
-
-        // Compute identity scores for the current sequence against the rest
-        for (j = i + 1; j < alig->originalNumberOfSequences; j++) {
-            if (alig->saveSequences[j] == -1) continue;
-            for (k = 0, hit = 0, dst = 0; k < alig->numberOfResidues; k++) {
-                if (alig->saveResidues[k] == -1) continue;
-                // If one of the two positions is a valid residue,
-                // count it for the common length
-                if (((alig->sequences[i][k] != indet) && (alig->sequences[i][k] != '-')) ||
-                    ((alig->sequences[j][k] != indet) && (alig->sequences[j][k] != '-'))) {
-                    dst++;
-                    // If both positions are the same, count a hit
-                    if (alig->sequences[i][k] == alig->sequences[j][k])
-                        hit++;
-                }
-            }
-
-            // Identity score between two sequences is the ratio of identical residues
-            // by the total length (common and no-common residues) among them
-            alig->identities[i][j] = (float) hit / dst;
-        }
-    }
-}
-
-void Cleaner::calculateRelaxedSeqIdentity() {
-    // Create a timer that will report times upon its destruction
-    //	which means the end of the current scope.
-    StartTiming("void Cleaner::calculateRelaxedSeqIdentity(void) ");
-    // Raw approximation of sequence identity computation designed for reducing
-    // comparisons for huge alignemnts
-
-    int i, j, k, hit;
-
-    float inverseResidNumber = 1.F / alig->originalNumberOfResidues;
-
-    // Create identities matrix to store identities scores
-    alig->identities = new float *[alig->originalNumberOfSequences];
-
-    // For each seq, compute its identity score against the others in the MSA
-    for (i = 0; i < alig->originalNumberOfSequences; i++) {
-        if (alig->saveSequences[i] == -1) continue;
-        alig->identities[i] = new float[alig->originalNumberOfSequences];
-
-        // It's a symmetric matrix, copy values that have been already computed
-        for (j = 0; j < i; j++) {
-            if (alig->saveSequences[j] == -1) continue;
-            alig->identities[i][j] = alig->identities[j][i];
-        }
-        alig->identities[i][i] = 0;
-
-        // Compute identity score between the selected sequence and the others
-        for (j = i + 1; j < alig->originalNumberOfSequences; j++) {
-            if (alig->saveSequences[j] == -1) continue;
-            for (k = 0, hit = 0; k < alig->originalNumberOfResidues; k++) {
-                if (alig->saveResidues[k] == -1) continue;
-                // If both positions are the same, count a hit
-                if (alig->sequences[i][k] == alig->sequences[j][k])
-                    hit++;
-            }
-            // Raw identity score is computed as the ratio of identical residues between
-            // alignment length 
-            alig->identities[i][j] = hit * inverseResidNumber;
-        }
-    }
-}
-
 int *Cleaner::calculateRepresentativeSeq(float maximumIdent) {
     // Create a timer that will report times upon its destruction
     //	which means the end of the current scope.
@@ -1533,8 +1442,8 @@ int *Cleaner::calculateRepresentativeSeq(float maximumIdent) {
     float max;
 
     // Ask for the sequence identities assesment
-    if (alig->identities == nullptr)
-        alig->Cleaning->calculateSeqIdentity();
+    alig->Statistics->calculateSeqIdentity();
+    float **identities = alig->Statistics->identity->identities;
 
     seqs = new int *[alig->originalNumberOfSequences];
     for (i = 0; i < alig->originalNumberOfSequences; i++) {
@@ -1555,9 +1464,9 @@ int *Cleaner::calculateRepresentativeSeq(float maximumIdent) {
         if (alig->saveSequences[i] == -1) continue;
 
         for (j = 0, max = 0, pos = -1; j < clusterNum; j++) {
-            if (alig->identities[seqs[i][1]][cluster[j]] > maximumIdent) {
-                if (alig->identities[seqs[i][1]][cluster[j]] > max) {
-                    max = alig->identities[seqs[i][1]][cluster[j]];
+            if (identities[seqs[i][1]][cluster[j]] > maximumIdent) {
+                if (identities[seqs[i][1]][cluster[j]] > max) {
+                    max = identities[seqs[i][1]][cluster[j]];
                     pos = j;
                 }
             }

--- a/source/Cleaner.cpp
+++ b/source/Cleaner.cpp
@@ -865,8 +865,7 @@ Alignment *Cleaner::cleanSpuriousSeq(float overlapColumn, float minimumOverlap, 
     overlapVector = new float[alig->originalNumberOfSequences];
 
     // Compute the overlap's vector using the overlap column's value
-    alig->Statistics->calculateSeqOverlap();
-    if (!alig->Statistics->overlap->calculateSpuriousVector(overlapColumn, overlapVector))
+    if (!alig->Statistics->calculateSpuriousVector(overlapColumn, overlapVector))
         return nullptr;
 
     // Select and remove the sequences with a overlap less than threshold's overlap and create a new alignment

--- a/source/Statistics/Identity.cpp
+++ b/source/Statistics/Identity.cpp
@@ -1,0 +1,162 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde M.             (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#include "Statistics/Identity.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Manager.h"
+#include "reportsystem.h"
+#include "Alignment/Alignment.h"
+#include "defines.h"
+#include "utils.h"
+
+namespace statistics {
+
+    Identity::Identity(Alignment *parentAlignment) {
+        StartTiming("Identity::Identity(Alignment *parentAlignment) ");
+       
+        alig = parentAlignment;
+        refCounter = new int(1);
+    }
+
+    Identity::Identity(Alignment *parentAlignment, Identity *mold) {
+        StartTiming("Identity::Identity(Alignment *parentAlignment, Identity *mold) ");
+
+        alig = parentAlignment;
+
+        identities = mold->identities;
+        refCounter = mold->refCounter;
+        (*refCounter)++;
+    }
+
+    void Identity::calculateSeqIdentity() {
+        // Create a timer that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("void Identity::calculateSeqIdentity(void) ");
+
+        int i, j, k, hit, dst;
+        char indet;
+
+        // Depending on alignment type, indetermination symbol will be one or other
+        indet = (alig->getAlignmentType() & SequenceTypes::AA) ? 'X' : 'N';
+
+        // Create identities matrix to store identities scores
+        identities = new float *[alig->originalNumberOfSequences];
+
+        // For each seq, compute its identity score against the others in the MSA
+        for (i = 0; i < alig->originalNumberOfSequences; i++) {
+            if (alig->saveSequences[i] == -1) continue;
+            identities[i] = new float[alig->originalNumberOfSequences];
+
+            // It's a symmetric matrix, copy values that have been already computed
+            for (j = 0; j < i; j++) {
+                if (alig->saveSequences[j] == -1) continue;
+                identities[i][j] = identities[j][i];
+            }
+            identities[i][i] = 0;
+
+            // Compute identity scores for the current sequence against the rest
+            for (j = i + 1; j < alig->originalNumberOfSequences; j++) {
+                if (alig->saveSequences[j] == -1) continue;
+                for (k = 0, hit = 0, dst = 0; k < alig->numberOfResidues; k++) {
+                    if (alig->saveResidues[k] == -1) continue;
+                    // If one of the two positions is a valid residue,
+                    // count it for the common length
+                    if (((alig->sequences[i][k] != indet) && (alig->sequences[i][k] != '-')) ||
+                        ((alig->sequences[j][k] != indet) && (alig->sequences[j][k] != '-'))) {
+                        dst++;
+                        // If both positions are the same, count a hit
+                        if (alig->sequences[i][k] == alig->sequences[j][k])
+                            hit++;
+                    }
+                }
+
+                // Identity score between two sequences is the ratio of identical residues
+                // by the total length (common and no-common residues) among them
+                identities[i][j] = (float) hit / dst;
+            }
+        }
+    }
+
+    void Identity::calculateRelaxedSeqIdentity() {
+        // Create a timer that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("void Identity::calculateRelaxedSeqIdentity(void) ");
+        // Raw approximation of sequence identity computation designed for reducing
+        // comparisons for huge alignemnts
+
+        int i, j, k, hit;
+
+        float inverseResidNumber = 1.F / alig->originalNumberOfResidues;
+
+        // Create identities matrix to store identities scores
+        identities = new float *[alig->originalNumberOfSequences];
+
+        // For each seq, compute its identity score against the others in the MSA
+        for (i = 0; i < alig->originalNumberOfSequences; i++) {
+            if (alig->saveSequences[i] == -1) continue;
+            identities[i] = new float[alig->originalNumberOfSequences];
+
+            // It's a symmetric matrix, copy values that have been already computed
+            for (j = 0; j < i; j++) {
+                if (alig->saveSequences[j] == -1) continue;
+                identities[i][j] = identities[j][i];
+            }
+            identities[i][i] = 0;
+
+            // Compute identity score between the selected sequence and the others
+            for (j = i + 1; j < alig->originalNumberOfSequences; j++) {
+                if (alig->saveSequences[j] == -1) continue;
+                for (k = 0, hit = 0; k < alig->originalNumberOfResidues; k++) {
+                    if (alig->saveResidues[k] == -1) continue;
+                    // If both positions are the same, count a hit
+                    if (alig->sequences[i][k] == alig->sequences[j][k])
+                        hit++;
+                }
+                // Raw identity score is computed as the ratio of identical residues between
+                // alignment length 
+                identities[i][j] = hit * inverseResidNumber;
+            }
+        }
+    }
+
+    Identity::~Identity() {
+        if (refCounter == nullptr || --(*refCounter) < 1) {
+            if (identities != nullptr) {
+                for (int i = 0; i < alig->numberOfSequences; i++)
+                    delete[] identities[i];
+                delete[] identities;
+            }
+            delete refCounter;
+            refCounter = nullptr;
+        }
+    }
+}

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -219,6 +219,24 @@ namespace statistics {
         return true;
     }
 
+    bool Manager::calculateSpuriousVector(float overlapColumn, float *spuriousVector) {
+        // Create a timerLevel that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("bool Manager::calculateSpuriousVector(float, float *) ");
+
+        // If Alignment matrix is not created, return false
+        if (alig->sequences == nullptr)
+            return false;
+
+        // If sgaps object is not created, we create them
+        // and calculate the statistics
+        if (overlap == nullptr) {
+            overlap = new Overlap(alig);
+        }
+
+        return overlap->calculateSpuriousVector(overlapColumn, spuriousVector);
+    }
+
     Manager::Manager(Alignment *parent) {
         // Create a timerLevel that will report times upon its destruction
         //	which means the end of the current scope.

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -29,8 +29,9 @@
 
 #include "Statistics/Similarity.h"
 #include "Statistics/Consistency.h"
-#include "InternalBenchmarker.h"
+#include "Statistics/Identity.h"
 #include "Statistics/Manager.h"
+#include "InternalBenchmarker.h"
 
 namespace statistics {
     bool Manager::calculateConservationStats() {
@@ -181,6 +182,24 @@ namespace statistics {
         return gaps->applyWindow(ghWindow);
     }
 
+    bool Manager::calculateSeqIdentity() {
+        // Create a timerLevel that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("bool Manager::calculateSeqIdentity(void) ");
+
+        // If Alignment matrix is not created, return false
+        if (alig->sequences == nullptr)
+            return false;
+
+        // If sgaps object is not created, we create them
+        // and calculate the statistics
+        if (identity == nullptr) {
+            identity = new Identity(alig);
+            identity->calculateSeqIdentity();
+        }
+        return true;
+    }
+
     Manager::Manager(Alignment *parent) {
         // Create a timerLevel that will report times upon its destruction
         //	which means the end of the current scope.
@@ -210,6 +229,9 @@ namespace statistics {
 
         if (mold->gaps)
             gaps = new Gaps(parent, mold->gaps);
+
+        if (mold->identity)
+            identity = new Identity(parent, mold->identity);
     }
 
     Manager::~Manager() {
@@ -221,5 +243,8 @@ namespace statistics {
 
         delete consistency;
         consistency = nullptr;
+
+        delete identity;
+        identity = nullptr;
     }
 }

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -31,6 +31,7 @@
 #include "Statistics/Consistency.h"
 #include "Statistics/Identity.h"
 #include "Statistics/Manager.h"
+#include "Statistics/Overlap.h"
 #include "InternalBenchmarker.h"
 
 namespace statistics {
@@ -200,6 +201,24 @@ namespace statistics {
         return true;
     }
 
+    bool Manager::calculateSeqOverlap() {
+        // Create a timerLevel that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("bool Manager::calculateSeqOverlap(void) ");
+
+        // If Alignment matrix is not created, return false
+        if (alig->sequences == nullptr)
+            return false;
+
+        // If sgaps object is not created, we create them
+        // and calculate the statistics
+        if (overlap == nullptr) {
+            overlap = new Overlap(alig);
+            overlap->calculateSeqOverlap();
+        }
+        return true;
+    }
+
     Manager::Manager(Alignment *parent) {
         // Create a timerLevel that will report times upon its destruction
         //	which means the end of the current scope.
@@ -232,6 +251,9 @@ namespace statistics {
 
         if (mold->identity)
             identity = new Identity(parent, mold->identity);
+
+        if (mold->overlap)
+            overlap = new Overlap(parent, mold->overlap);
     }
 
     Manager::~Manager() {
@@ -246,5 +268,8 @@ namespace statistics {
 
         delete identity;
         identity = nullptr;
+
+        delete overlap;
+        overlap = nullptr;
     }
 }

--- a/source/Statistics/Overlap.cpp
+++ b/source/Statistics/Overlap.cpp
@@ -124,7 +124,8 @@ namespace statistics {
             return false; 
 
         // calculate overlap for each column of every sequence
-        calculateSeqOverlap();
+        if (overlaps == nullptr)
+            calculateSeqOverlap();
 
         for (i = 0, seqValue = 0; i < alig->originalNumberOfSequences; i++, seqValue = 0) {
             // For each Alignment's column, computes the overlap

--- a/source/Statistics/Overlap.cpp
+++ b/source/Statistics/Overlap.cpp
@@ -1,0 +1,145 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde M.             (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#include "Statistics/Overlap.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Manager.h"
+#include "reportsystem.h"
+#include "Alignment/Alignment.h"
+#include "defines.h"
+#include "utils.h"
+
+namespace statistics {
+
+    Overlap::Overlap(Alignment *parentAlignment) {
+        StartTiming("Overlap::Overlap(Alignment *parentAlignment) ");
+       
+        alig = parentAlignment;
+        refCounter = new int(1);
+    }
+
+    Overlap::Overlap(Alignment *parentAlignment, Overlap *mold) {
+        StartTiming("Overlap::Overlap(Alignment *parentAlignment, Overlap *mold) ");
+
+        alig = parentAlignment;
+
+        overlaps = mold->overlaps;
+        refCounter = mold->refCounter;
+        (*refCounter)++;
+    }
+
+    Overlap::~Overlap() {
+        if (refCounter == nullptr || --(*refCounter) < 1) {
+            if (overlaps != nullptr) {
+                for (int i = 0; i < alig->numberOfSequences; i++)
+                    delete[] overlaps[i];
+                delete[] overlaps;
+            }
+            delete refCounter;
+            refCounter = nullptr;
+        }
+    }
+
+    void Overlap::calculateSeqOverlap() {
+        // Create a timer that will report times upon its destruction
+        //	which means the end of the current scope.
+        StartTiming("bool Overlap::calculateOverlap() ");
+
+        int i, j, k;
+        char indet;
+
+        // Create identities matrix to store identities scores
+        overlaps = new int *[alig->originalNumberOfSequences];
+
+        // Depending on the kind of Alignment, we have
+        // different indetermination symbol
+        if (alig->getAlignmentType() & SequenceTypes::AA)
+            indet = 'X';
+        else
+            indet = 'N';
+        // For each Alignment's sequence, computes its overlap
+        for (i = 0; i < alig->originalNumberOfSequences; i++) {
+            overlaps[i] = new int [alig->originalNumberOfResidues];
+
+            // For each Alignment's column, computes the overlap
+            // between the selected sequence and the other ones
+            for (j = 0; j < alig->originalNumberOfResidues; j++) {
+                for (k = 0; k < i; k++) {
+                    // Don't compare a sequence to itself
+                    if (k == i) continue;
+                    // If the element of sequence selected is the same
+                    // that the element of sequence considered, computes
+                    // a hit
+                    if (alig->sequences[i][j] == alig->sequences[k][j])
+                        overlaps[i][j]++;
+                        // If the element of sequence selected isn't a 'X' nor
+                        // 'N' (indetermination) or a '-' (gap) and the element
+                        // of sequence considered isn't a  a 'X' nor 'N'
+                        // (indetermination) or a '-' (gap), computes a hit
+                    else if ((alig->sequences[i][j] != indet) && (alig->sequences[i][j] != '-')
+                            && (alig->sequences[k][j] != indet) && (alig->sequences[k][j] != '-'))
+                        overlaps[i][j]++;
+                }
+            }
+        }
+    }
+
+    bool Overlap::calculateSpuriousVector(float overlapColumn, float *spuriousVector) {
+        int i, j, ovrlap, seqValue;
+
+        float floatOverlap = overlapColumn * float(alig->originalNumberOfSequences - 1);
+        ovrlap = int(overlapColumn * (alig->originalNumberOfSequences - 1));
+        if (floatOverlap > float(ovrlap))
+            ovrlap++;
+        if (spuriousVector == nullptr)
+            return false; 
+
+        // calculate overlap for each column of every sequence
+        calculateSeqOverlap();
+
+        for (i = 0, seqValue = 0; i < alig->originalNumberOfSequences; i++, seqValue = 0) {
+            // For each Alignment's column, computes the overlap
+            // between the selected sequence and the other ones
+            for (j = 0; j < alig->originalNumberOfResidues; j++) {
+                if (overlaps[i][j] >= ovrlap)
+                    seqValue++;
+            }
+
+            // For each Alignment's sequence, computes its spurious's
+            // or overlap's value as the column's hits -for that
+            // sequence- divided by column's number.
+            spuriousVector[i] = ((float) seqValue / alig->originalNumberOfResidues);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Hi @nicodr97!

This is an initial PR before I add the SIMD code to move all statistics computation under the `Manager` control, instead of having identity and overlap computed by the `Cleaner` class. This way the statistics are all computed by `Manager`, which will make it easier to implement the SIMD variants and the dynamic dispatching.