### PR TITLE
Improve performance of sequence length computation

### DIFF
--- a/include/Alignment/Alignment.h
+++ b/include/Alignment/Alignment.h
@@ -115,6 +115,11 @@ public:
 
     bool getSequenceNameOrder(std::string *names, int *orderVector);
 
+    /**
+     * \brief Get the length of a sequence without gap characters
+     */
+    int getSequenceLength(size_t index);
+
     int getNumAminos();
 
     void setWindowsSize(int ghWindow, int shWindow);

--- a/include/utils.h
+++ b/include/utils.h
@@ -303,6 +303,14 @@ namespace utils {
      \param line String to remove c from.
      \return New string without c character
      */
+    int countCharacter(char c, const std::string &line);
+
+    /**
+     \brief Count the number of occurences of a determined char in the string
+     \param c Character to count
+     \param line String to count c in.
+     \return Number of occurences of c character
+     */
      std::string removeCharacter(char c, std::string line);
 
     /**

--- a/include/utils.h
+++ b/include/utils.h
@@ -296,20 +296,20 @@ namespace utils {
      \return Reversed string of toReverse.
      */
      std::string getReverse(const std::string &toReverse);
+    
+    /**
+     \brief Count the number of occurences of a determined char in the string.
+     \param c Character to count.
+     \param line String to count c in.
+     \return Number of occurences of c character.
+     */
+    int countCharacter(char c, const std::string &line);
 
     /**
      \brief Removes a determined char from the string
      \param c Character to remove from line
      \param line String to remove c from.
      \return New string without c character
-     */
-    int countCharacter(char c, const std::string &line);
-
-    /**
-     \brief Count the number of occurences of a determined char in the string
-     \param c Character to count
-     \param line String to count c in.
-     \return Number of occurences of c character
      */
      std::string removeCharacter(char c, std::string line);
 

--- a/source/Alignment/Alignment.cpp
+++ b/source/Alignment/Alignment.cpp
@@ -442,6 +442,10 @@ void Alignment::getSequences(string *Names, string *Sequences, int *lengths) {
     }
 }
 
+int Alignment::getSequenceLength(size_t index) {
+    return sequences[index].size() - utils::countCharacter('-', sequences[index]);
+}
+
 bool Alignment::getSequenceNameOrder(string *names, int *orderVector) {
     // Create a timer that will report times upon its destruction
     //	which means the end of the current scope.

--- a/source/Alignment/Alignment.cpp
+++ b/source/Alignment/Alignment.cpp
@@ -426,7 +426,7 @@ void Alignment::getSequences(string *Names, int *lenghts) {
     //	which means the end of the current scope.
     StartTiming("void Alignment::getSequences(string *Names, int *lengths) ");
     for (int i = 0; i < numberOfSequences; i++) {
-        lenghts[i] = (int) utils::removeCharacter('-', sequences[i]).length();
+        lenghts[i] = getSequenceLength(i);
         Names[i] = seqsName[i];
     }
 }

--- a/source/Cleaner.cpp
+++ b/source/Cleaner.cpp
@@ -1118,7 +1118,7 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
     seqs = new int *[alig->numberOfSequences];
     for (i = 0; i < alig->numberOfSequences; i++) {
         seqs[i] = new int[2];
-        seqs[i][0] = utils::removeCharacter('-', alig->sequences[i]).size();
+        seqs[i][0] = alig->getSequenceLength(i);
         seqs[i][1] = i;
     }
     utils::quicksort(seqs, 0, alig->numberOfSequences - 1);
@@ -1540,7 +1540,7 @@ int *Cleaner::calculateRepresentativeSeq(float maximumIdent) {
     for (i = 0; i < alig->originalNumberOfSequences; i++) {
         if (alig->saveSequences[i] == -1) continue;
         seqs[i] = new int[2];
-        seqs[i][0] = utils::removeCharacter('-', alig->sequences[i]).size();
+        seqs[i][0] = alig->getSequenceLength(i);
         seqs[i][1] = i;
     }
 

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -482,6 +482,19 @@ namespace utils {
         return line;
     }
 
+    int countCharacter(char c, const std::string &line) {
+        size_t pos;
+        int n = 0;
+
+        pos = line.find(c, 0);
+        while (pos != (int) std::string::npos) {
+            n++;
+            pos = line.find(c, pos + 1);
+        }
+
+        return n;
+    }
+
     std::string removeCharacter(char c, std::string line) {
 
         size_t pos;

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -483,17 +483,28 @@ namespace utils {
     }
 
     int countCharacter(char c, const std::string &line) {
-        size_t pos;
-        int n = 0;
+        size_t len = line.size();
+        size_t start = 0;
+        size_t end = len;
+        int n;
 
-        pos = line.find(c, 0);
-        while (pos != (int) std::string::npos) {
-            n++;
-            pos = line.find(c, pos + 1);
+        const char* ptr = nullptr;
+        const char* data = line.data();
+
+        for (n = 0; start < end;) {
+            ptr = reinterpret_cast<const char*>(memchr(data + start, c, end - start));
+            if (ptr == nullptr) {
+                start = end;
+            } else {
+                std::ptrdiff_t diff = ptr - data;
+                start = diff + 1;
+                n++;
+            }
         }
 
         return n;
     }
+
 
     std::string removeCharacter(char c, std::string line) {
 

--- a/tests/source/utils/stringManipulation.cpp
+++ b/tests/source/utils/stringManipulation.cpp
@@ -117,6 +117,32 @@ TEST_CASE("stringManipulation", "[utils]") {
         }
     }
 
+    WHEN("Counting character in a line") {
+        GIVEN("ABCDEF - 'A'") {
+            std::string str("ABCDEF");
+            CAPTURE(str);
+            CHECK(utils::countCharacter('A', str) == 1);
+        }
+
+        GIVEN("ABCDEF - 'H'") {
+            std::string str("ABCDEF");
+            CAPTURE(str);
+            CHECK(utils::countCharacter('H', str) == 0);
+        }
+
+        GIVEN("ABABBABB - 'A'") {
+            std::string str("ABABBABB");
+            CAPTURE(str);
+            CHECK(utils::countCharacter('A', str) == 3);
+        }
+
+        GIVEN("ABABBABB - 'B'") {
+            std::string str("ABABBABB");
+            CAPTURE(str);
+            CHECK(utils::countCharacter('B', str) == 5);
+        }
+    }
+
     WHEN("Reading numbers") {
         std::unique_ptr<int[]> ptr;
         GIVEN("Empty string") {


### PR DESCRIPTION
Hi again,

I noticed while working on #72 that there were a couple of locations where a sequence would be copied for the sole purpose of computing its (ungapped) length, which is not really efficient. I added a new dedicated `Alignment` method for getting the length of a sequence without copy, based on the new `utils::countCharacter` function added here as well.

The implementation of `utils::countCharacter` uses [`memchr`](https://cplusplus.com/reference/cstring/memchr/) rather than [`std::count`](https://cplusplus.com/reference/algorithm/count/) or a naive implementation because [it is faster](https://gms.tf/stdfind-and-memchr-optimizations.html). It does increase performance when running in `-clusters` mode (I got a x1.3 to x1.5 improvement):

<details>

<pre>
Benchmark 1: ./trimal_2.0 -in ../dataset/example.015.AA.bctoNOG.ENOG41099F3.fasta -clusters 5
  Time (mean ± σ):     30.104 s ±  1.319 s    [User: 29.951 s, System: 0.051 s]
  Range (min … max):   29.006 s … 31.567 s    3 runs
 
Benchmark 2: ./trimal_memchr -in ../dataset/example.015.AA.bctoNOG.ENOG41099F3.fasta -clusters 5
  Time (mean ± σ):     22.973 s ±  0.485 s    [User: 22.798 s, System: 0.071 s]
  Range (min … max):   22.620 s … 23.526 s    3 runs
 
Summary
  './trimal_memchr -in ../dataset/example.015.AA.bctoNOG.ENOG41099F3.fasta -clusters 5' ran
    1.31 ± 0.06 times faster than './trimal_2.0 -in ../dataset/example.015.AA.bctoNOG.ENOG41099F3.fasta -clusters 5'
</pre>

</details>


