### PR TITLE
Add SIMD implementation of the different statistics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,31 +7,33 @@ set(CMAKE_CXX_STANDARD 11)
 # Specify bin folder to output the compiled programs
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 
+# Set common files for all executables
+set(TRIMAL_OBJECTS
+    $<TARGET_OBJECTS:CoreOBJLib>
+    $<TARGET_OBJECTS:FormatsOBJLib>
+    $<TARGET_OBJECTS:FormatHandlerOBJLib>
+    $<TARGET_OBJECTS:ReportSystemOBJLib>
+    $<TARGET_OBJECTS:StatisticOBJLib>
+    $<TARGET_OBJECTS:UtilsOBJLib>
+    $<TARGET_OBJECTS:InternalBenchmarkOBJLib>)
+
+# Add SIMD code if compiler supports it
+if (HAVE_SSE2)
+    list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:SSE2OBJLib>)
+endif()
+
 # Add the executables to the project.
 add_executable(trimal
         source/trimAlMain.cpp               # Main
         source/trimalManager.cpp            # trimAl Manager
 
         source/VCFHandler.cpp               # VCF only present on trimAl
-        # No need to transform to OBJLib
-        $<TARGET_OBJECTS:CoreOBJLib>
-        $<TARGET_OBJECTS:FormatsOBJLib>
-        $<TARGET_OBJECTS:FormatHandlerOBJLib>
-        $<TARGET_OBJECTS:ReportSystemOBJLib>
-        $<TARGET_OBJECTS:StatisticOBJLib>
-        $<TARGET_OBJECTS:UtilsOBJLib>
-        $<TARGET_OBJECTS:InternalBenchmarkOBJLib>)
+        ${TRIMAL_OBJECTS})
 
 add_executable(readal
         source/FormatHandling/readAlMain.cpp        # Main
 
-        $<TARGET_OBJECTS:CoreOBJLib>
-        $<TARGET_OBJECTS:FormatsOBJLib>
-        $<TARGET_OBJECTS:FormatHandlerOBJLib>
-        $<TARGET_OBJECTS:ReportSystemOBJLib>
-        $<TARGET_OBJECTS:StatisticOBJLib>
-        $<TARGET_OBJECTS:UtilsOBJLib>
-        $<TARGET_OBJECTS:InternalBenchmarkOBJLib>)
+       ${TRIMAL_OBJECTS})
 
 # Add the executables to the project.
 add_executable(test
@@ -40,17 +42,7 @@ add_executable(test
         source/trimalManager.cpp            # trimAl Manager
 
         source/VCFHandler.cpp               # VCF only present on trimAl
-        # No need to transform to OBJLib
-        $<TARGET_OBJECTS:CoreOBJLib>
-        $<TARGET_OBJECTS:FormatsOBJLib>
-        $<TARGET_OBJECTS:FormatHandlerOBJLib>
-        $<TARGET_OBJECTS:ReportSystemOBJLib>
-        $<TARGET_OBJECTS:StatisticOBJLib>
-        $<TARGET_OBJECTS:UtilsOBJLib>
-        $<TARGET_OBJECTS:InternalBenchmarkOBJLib>
-        $<TARGET_OBJECTS:CatchOBJLib>
-        $<TARGET_OBJECTS:TestsOBJLib>
-        )
+        ${TRIMAL_OBJECTS})
 SET_TARGET_PROPERTIES(test PROPERTIES EXCLUDE_FROM_ALL True)
 
 # Link the mathematical library to the targets
@@ -58,6 +50,10 @@ target_link_libraries(trimal m)
 target_link_libraries(readal m)
 
 target_link_libraries(test stdc++fs)
+
+
+# Scripts to detect various SIMD support for the current compiler
+include("./scripts/CMake/FindSSE2.cmake")
 
 # Script that sets Release type to default and prints information on configuration
 include("./scripts/CMake/BuildTypeWrapper.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ set(TRIMAL_OBJECTS
     $<TARGET_OBJECTS:UtilsOBJLib>
     $<TARGET_OBJECTS:InternalBenchmarkOBJLib>)
 
+# Scripts to detect various SIMD support for the current compiler
+include("./scripts/CMake/FindAVX2.cmake")
+include("./scripts/CMake/FindNEON.cmake")
+include("./scripts/CMake/FindSSE2.cmake")
+
 # Add SIMD code if compiler supports it
 if (HAVE_SSE2)
     list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:SSE2OBJLib>)
@@ -56,12 +61,6 @@ target_link_libraries(trimal m)
 target_link_libraries(readal m)
 
 target_link_libraries(test stdc++fs)
-
-
-# Scripts to detect various SIMD support for the current compiler
-include("./scripts/CMake/FindAVX2.cmake")
-include("./scripts/CMake/FindNEON.cmake")
-include("./scripts/CMake/FindSSE2.cmake")
 
 # Script that sets Release type to default and prints information on configuration
 include("./scripts/CMake/BuildTypeWrapper.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(TRIMAL_OBJECTS
 if (HAVE_SSE2)
     list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:SSE2OBJLib>)
 endif()
+if (HAVE_AVX2)
+    list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:AVX2OBJLib>)
+endif()
 
 # Add the executables to the project.
 add_executable(trimal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ endif()
 if (HAVE_AVX2)
     list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:AVX2OBJLib>)
 endif()
+if (HAVE_NEON)
+    list(APPEND TRIMAL_OBJECTS $<TARGET_OBJECTS:NEONOBJLib>)
+endif()
 
 # Add the executables to the project.
 add_executable(trimal
@@ -56,6 +59,8 @@ target_link_libraries(test stdc++fs)
 
 
 # Scripts to detect various SIMD support for the current compiler
+include("./scripts/CMake/FindAVX2.cmake")
+include("./scripts/CMake/FindNEON.cmake")
 include("./scripts/CMake/FindSSE2.cmake")
 
 # Script that sets Release type to default and prints information on configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,15 @@ set(TRIMAL_OBJECTS
     $<TARGET_OBJECTS:InternalBenchmarkOBJLib>)
 
 # Scripts to detect various SIMD support for the current compiler
-include("./scripts/CMake/FindAVX2.cmake")
-include("./scripts/CMake/FindNEON.cmake")
-include("./scripts/CMake/FindSSE2.cmake")
+if (NOT DISABLE_AVX2)
+    include("./scripts/CMake/FindAVX2.cmake")
+endif()
+if (NOT DISABLE_NEON)
+    include("./scripts/CMake/FindNEON.cmake")
+endif()
+if (NOT DISABLE_SSE2)
+    include("./scripts/CMake/FindSSE2.cmake")
+endif()
 
 # Add SIMD code if compiler supports it
 if (HAVE_SSE2)

--- a/include/Cleaner.h
+++ b/include/Cleaner.h
@@ -471,7 +471,7 @@ private:
     /**
      \brief Destructor
      */
-    virtual ~Cleaner() {};
+    ~Cleaner() {};
 };
 
 

--- a/include/Cleaner.h
+++ b/include/Cleaner.h
@@ -468,6 +468,10 @@ private:
      */
     Cleaner(Alignment *parent, Cleaner *mold);
 
+    /**
+     \brief Destructor
+     */
+    virtual ~Cleaner() {};
 };
 
 

--- a/include/Platform/Arm/NEON.h
+++ b/include/Platform/Arm/NEON.h
@@ -1,0 +1,75 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef TRIMAL_PLATFORM_X86_NEON_H
+#define TRIMAL_PLATFORM_X86_NEON_H
+
+#include "Statistics/Identity.h"
+#include "Statistics/Gaps.h"
+#include "Statistics/Overlap.h"
+#include "Statistics/Similarity.h"
+
+namespace statistics {
+
+class NEONSimilarity : public Similarity {
+public:
+  NEONSimilarity(Alignment *parentAlignment) : Similarity(parentAlignment) {}
+  NEONSimilarity(Alignment *parentAlignment, Similarity *parentSimilarity) :
+    Similarity(parentAlignment, parentSimilarity) {}
+  void calculateMatrixIdentity() override;
+  bool calculateVectors(bool cutByGap) override;
+};
+class NEONGaps : public Gaps {
+public:
+  NEONGaps(Alignment *parentAlignment) : Gaps(parentAlignment) {}
+  NEONGaps(Alignment *parentAlignment, Gaps *parentGaps):
+    Gaps(parentAlignment, parentGaps) {}
+  void CalculateVectors() override;
+};
+
+class NEONOverlap : public Overlap {
+public:
+  NEONOverlap(Alignment *parent) : Overlap(parent) {}
+  NEONOverlap(Alignment *parent, Overlap *parentOverlap) : Overlap(parent, parentOverlap) {}
+  bool calculateSpuriousVector(float overlap, float *spuriousVector) override;
+};
+
+class NEONIdentity : public Identity {
+public:
+  NEONIdentity(Alignment *parent) : Identity(parent) {}
+  NEONIdentity(Alignment *parent, Identity *parentIdentity) : Identity(parent, parentIdentity) {}
+  void calculateSeqIdentity() override;
+};
+
+} // namespace statistics
+
+#endif

--- a/include/Platform/template.h
+++ b/include/Platform/template.h
@@ -1,0 +1,611 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef TRIMAL_PLATFORM_TEMPLATE_H
+#define TRIMAL_PLATFORM_TEMPLATE_H
+
+#include <cstdlib>
+#include <climits>
+
+#include "Alignment/Alignment.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Manager.h"
+#include "Statistics/Similarity.h"
+#include "Statistics/similarityMatrix.h"
+#include "Statistics/Identity.h"
+#include "defines.h"
+#include "reportsystem.h"
+#include "utils.h"
+
+namespace simd {
+
+template <class T, class Vector> 
+T *aligned_array(size_t n) {
+  T* ptr = nullptr;
+  if (Vector::SIZE > 1) {
+    const size_t mask = Vector::SIZE - 1;
+    const size_t size = (n * sizeof(T) + mask) & (~mask);
+    void* memptr = nullptr;
+    if (posix_memalign(&memptr, Vector::SIZE, size) == 0)
+      ptr = static_cast<T *>(memptr);
+  } else {
+    const size_t size = (n * sizeof(T));
+    ptr = static_cast<T *>(malloc(size));
+  }
+  if (ptr == nullptr)
+    throw std::bad_alloc();
+  return ptr;
+}
+
+template <class Vector>
+inline void calculateMatrixIdentity(statistics::Similarity &s) {
+
+  // abort if identity matrix computation was already done
+  if (s.matrixIdentity != nullptr)
+    return;
+
+  // Allocate memory for the matrix identity
+  s.matrixIdentity = new float *[s.alig->originalNumberOfSequences];
+  for (int i = 0; i < s.alig->originalNumberOfSequences; i++) {
+    s.matrixIdentity[i] = new float[s.alig->originalNumberOfSequences];
+  }
+
+  // declare indices
+  int i, j, k, l;
+
+  // Depending on alignment type, indetermination symbol will be one or other
+  char indet = s.alig->getAlignmentType() & SequenceTypes::AA ? 'X' : 'N';
+
+  // prepare constant SIMD vectors
+  const Vector ALLINDET = Vector::duplicate(indet);
+  const Vector ALLGAP = Vector::duplicate('-');
+  const Vector ONES = Vector::duplicate(1);
+
+  // For each sequences' pair, compare identity
+  for (i = 0; i < s.alig->originalNumberOfSequences; i++) {
+
+    const uint8_t *datai =
+        reinterpret_cast<const uint8_t *>(s.alig->sequences[i].data());
+
+    for (j = i + 1; j < s.alig->originalNumberOfSequences; j++) {
+
+      const uint8_t *dataj =
+          reinterpret_cast<const uint8_t *>(s.alig->sequences[j].data());
+
+      Vector len_acc = Vector();
+      Vector sum_acc = Vector();
+
+      uint32_t sum = 0;
+      uint32_t length = 0;
+
+      // run with unrolled loops of UCHAR_MAX iterations first
+      for (k = 0; ((int)(k + Vector::LANES * UCHAR_MAX)) <
+                  s.alig->originalNumberOfResidues;) {
+        // unroll the internal loop
+        for (l = 0; l < UCHAR_MAX; l++, k += Vector::LANES) {
+          // load data for the sequences
+          Vector seqi = Vector::loadu(&datai[k]);
+          Vector seqj = Vector::loadu(&dataj[k]);
+          // find which sequence characters are gap or indet
+          Vector gapsi = (seqi == ALLGAP) | (seqi == ALLINDET);
+          Vector gapsj = (seqj == ALLGAP) | (seqj == ALLINDET);
+          // find which sequence characters are equal
+          Vector eq = (seqi == seqj);
+          // update counters
+          sum_acc += eq & ONES.andnot(gapsi | gapsj);
+          len_acc += ONES.andnot(gapsi & gapsj);
+        }
+        // merge accumulators
+        sum += sum_acc.sum();
+        length += len_acc.sum();
+        sum_acc.clear();
+        len_acc.clear();
+      }
+
+      // run remaining iterations in SIMD while possible
+      for (; ((int)(k + Vector::LANES)) < s.alig->originalNumberOfResidues;
+           k += Vector::LANES) {
+        // load data for the sequences
+        Vector seqi = Vector::loadu(&datai[k]);
+        Vector seqj = Vector::loadu(&dataj[k]);
+        // find which sequence characters are gap or indet
+        Vector gapsi = (seqi == ALLGAP) | (seqi == ALLINDET);
+        Vector gapsj = (seqj == ALLGAP) | (seqj == ALLINDET);
+        // find which sequence characters are equal
+        Vector eq = (seqi == seqj);
+        // update counters
+        sum_acc += eq & ONES.andnot(gapsi | gapsj);
+        len_acc += ONES.andnot(gapsi & gapsj);
+      }
+
+      // // merge accumulators
+      sum += sum_acc.sum();
+      length += len_acc.sum();
+
+      // process the tail elements when there remain less than
+      // can be fitted in a SIMD vector
+      for (; k < s.alig->originalNumberOfResidues; k++) {
+        int gapi = (datai[k] == '-') || (datai[k] == indet);
+        int gapj = (dataj[k] == '-') || (dataj[k] == indet);
+        sum += (!gapi) && (!gapj) && (datai[k] == dataj[k]);
+        length += (!gapi) || (!gapj);
+      }
+
+      // Calculate the value of matrix idn for columns j and i
+      s.matrixIdentity[i][j] = s.matrixIdentity[j][i] =
+          (1.0F - ((float)sum / length));
+    }
+  }
+}
+
+template <class Vector>
+inline bool calculateSimilarityVectors(statistics::Similarity &s,
+                                       bool cutByGap) {
+  // A similarity matrix must be defined. If not, return false
+  if (s.simMatrix == nullptr)
+    return false;
+
+  // Get the similarity matrix raw storage
+  const float** distMat = s.simMatrix->getDistanceMatrix();
+
+  // Calculate the matrix identity in case it's not done before
+  if (s.matrixIdentity == nullptr)
+    s.calculateMatrixIdentity();
+
+  // Create the variable gaps, in case we want to cut by gaps
+  int *gaps = nullptr;
+
+  // Retrieve the gaps values in case we want to set to 0 the similarity value
+  // in case the gaps value for that column is bigger or equal to 0.8F
+  if (cutByGap) {
+    if (s.alig->Statistics->gaps == nullptr)
+      s.alig->Statistics->calculateGapStats();
+    gaps = s.alig->Statistics->gaps->getGapsWindow();
+  }
+
+  // Initialize the variables used
+  int i, j, k;
+  float num, den;
+
+  // Depending on alignment type, indetermination symbol will be one or other
+  char indet = s.alig->getAlignmentType() & SequenceTypes::AA ? 'X' : 'N';
+
+  // Q temporal value
+  float Q;
+  // Temporal chars that will contain the residues to compare by pair.
+  int numA, numB;
+
+  // Calculate the maximum number of gaps a column can have to calculate it's
+  //      similarity
+  float gapThreshold = 0.8F * s.alig->numberOfResidues;
+
+  // Cache pointers to matrix rows to avoid dereferencing in inner loops
+  const float *identityRow;
+  const float *distRow;
+
+  // Create buffers to store column data
+  std::vector<char> colnum =
+      std::vector<char>(s.alig->originalNumberOfSequences);
+  std::vector<char> colgap =
+      std::vector<char>(s.alig->originalNumberOfSequences);
+
+  // For each column calculate the Q value and the MD value using an equation
+  for (i = 0; i < s.alig->originalNumberOfResidues; i++) {
+    // Set MDK for columns with gaps values bigger or equal to threshold
+    if ((gaps != nullptr) && gaps[i] >= gapThreshold) {
+      s.MDK[i] = 0.F;
+      continue;
+    }
+
+    // Fill the column buffer with the current column and check
+    // characters are well-defined with respect to the similarity matrix
+    for (j = 0; j < s.alig->originalNumberOfSequences; j++) {
+      char letter = utils::toUpper(s.alig->sequences[j][i]);
+      if ((letter == indet) || (letter == '-')) {
+        colgap[j] = 1;
+      } else {
+        colgap[j] = 0;
+        if ((letter < 'A') || (letter > 'Z')) {
+          debug.report(ErrorCode::IncorrectSymbol,
+                       new std::string[1]{std::string(1, letter)});
+          return false;
+        } else {
+            int index = s.simMatrix->getLetterIndex(letter);
+            if (index == -1) {
+                debug.report(ErrorCode::UndefinedSymbol,
+                            new std::string[1]{std::string(1, letter)});
+                return false;
+            } else {
+                colnum[j] = index;
+            }
+        }
+      }
+    }
+
+    // For each AAs/Nucleotides' pair in the column we compute its distance
+    for (j = 0, num = 0, den = 0; j < s.alig->originalNumberOfSequences; j++) {
+      // We don't compute the distance if the first element is
+      // a indeterminate (XN) or a gap (-) element.
+      if (colgap[j])
+        continue;
+
+      // Get the index of the first residue
+      // and cache pointers to matrix rows
+      numA = colnum[j];
+      distRow = distMat[numA];
+      identityRow = s.matrixIdentity[j];
+
+      for (k = j + 1; k < s.alig->originalNumberOfSequences; k++) {
+        // We don't compute the distance if the second element is
+        //      a indeterminate (XN) or a gap (-) element
+        if (colgap[k])
+          continue;
+
+        // Get the index of the second residue and compute
+        // fraction with identity value for the two pairs and
+        // its distance based on similarity matrix's value.
+        numB = colnum[k];
+        num += identityRow[k] * distRow[numB];
+        den += identityRow[k];
+      }
+    }
+
+    // If we are processing a column with only one AA/nucleotide, MDK = 0
+    if (den == 0) {
+      s.MDK[i] = 0;
+    } else {
+      Q = num / den;
+      // If the MDK value is more than 1, we normalized this value to 1.
+      //      Only numbers higher than 0 yield exponents higher than 1
+      //      Using this we can test if the result is going to be higher than 1.
+      //      And thus, prevent calculating the exp.
+      // Take in mind that the Q is negative, so we must test if Q is LESSER
+      //      than one, not bigger.
+      if (Q < 0)
+        s.MDK[i] = 1.F;
+      else
+        s.MDK[i] = exp(-Q);
+    }
+  }
+
+  // Free the identity matrix now that it's not useful anymore
+  for (int i = 0; i < s.alig->originalNumberOfSequences; i++)
+    delete[] s.matrixIdentity[i];
+  delete[] s.matrixIdentity;
+  s.matrixIdentity = nullptr;
+
+  return true;
+}
+
+template <class Vector>
+inline bool calculateSpuriousVector(statistics::Overlap &o, const float overlap,
+                                    float *spuriousVector) {
+  // abort if there is not output vector to write to
+  if (spuriousVector == nullptr)
+    return false;
+
+  // Get the alignment from the Cleaner object
+  const Alignment* alig = o.alig;
+
+  // compute number of sequences from overlap threshold
+  uint32_t ovrlap =
+      uint32_t(ceil(overlap * float(alig->originalNumberOfSequences - 1)));
+
+
+
+  // Depending on alignment type, indetermination symbol will be one or other
+  char indet = (alig->getAlignmentType() & SequenceTypes::AA) ? 'X' : 'N';
+
+  // prepare constant SIMD vectors
+  const Vector ALLINDET = Vector::duplicate(indet);
+  const Vector ALLGAP = Vector::duplicate('-');
+  const Vector ONES = Vector::duplicate(1);
+
+  // allocate aligned memory for faster SIMD loads
+  uint32_t *hits =
+      aligned_array<uint32_t, Vector>(alig->originalNumberOfResidues);
+  uint8_t *hits_u8 =
+      aligned_array<uint8_t, Vector>(alig->originalNumberOfResidues);
+
+  // for each sequence in the alignment, computes its overlap
+  for (int i = 0; i < alig->originalNumberOfSequences; i++) {
+
+    // reset hits count
+    memset(&hits[0], 0, alig->originalNumberOfResidues * sizeof(uint32_t));
+    memset(&hits_u8[0], 0, alig->originalNumberOfResidues * sizeof(uint8_t));
+
+    const uint8_t *datai =
+        reinterpret_cast<const uint8_t *>(alig->sequences[i].data());
+
+    // compare sequence to other sequences for every position
+    for (int j = 0; j < alig->originalNumberOfSequences; j++) {
+
+      // don't compare sequence to itself
+      if (j == i)
+        continue;
+
+      const uint8_t *dataj =
+          reinterpret_cast<const uint8_t *>(alig->sequences[j].data());
+
+      int k = 0;
+
+      // run iterations in SIMD while possible
+      for (; ((int)(k + Vector::LANES)) <= alig->originalNumberOfResidues;
+           k += Vector::LANES) {
+        // load data for the sequences
+        const Vector seqi = Vector::loadu(&datai[k]);
+        const Vector seqj = Vector::loadu(&dataj[k]);
+        // find which sequence characters are gap or indet
+        const Vector gapsi = (seqi == ALLGAP) | (seqi == ALLINDET);
+        const Vector gapsj = (seqj == ALLGAP) | (seqj == ALLINDET);
+        const Vector gaps = !(gapsi | gapsj);
+        // find which sequence characters match
+        const Vector eq = (seqi == seqj);
+        // find position where either not both characters are gap, or they are
+        // equal
+        const Vector n = (eq | gaps) & ONES;
+        // update counters
+        Vector hit = Vector::load(&hits_u8[k]);
+        hit += n;
+        hit.store(&hits_u8[k]);
+      }
+
+      // process the tail elements when there remain less than
+      // can be fitted in a SIMD vector
+      for (; k < alig->originalNumberOfResidues; k++) {
+        int nongapi = (datai[k] != indet) && (datai[k] != '-');
+        int nongapj = (dataj[k] != indet) && (dataj[k] != '-');
+        hits_u8[k] += ((nongapi && nongapj) || (datai[k] == dataj[k]));
+      }
+
+      // we can process up to UCHAR_MAX sequences, otherwise hits_u8[k]
+      // may overflow, so every UCHAR_MAX iterations we transfer the
+      // partial hit counts from `hits_u8` to `hits`
+      if ((j % UCHAR_MAX) == 0) {
+        for (k = 0; k < alig->originalNumberOfResidues; k++)
+          hits[k] += hits_u8[k];
+        memset(hits_u8, 0, alig->originalNumberOfResidues * sizeof(uint8_t));
+      }
+    }
+
+    // update counters after last loop
+    for (int k = 0; k < alig->originalNumberOfResidues; k++)
+      hits[k] += hits_u8[k];
+
+    // compute number of good positions in for sequence i
+    uint32_t seqValue = 0;
+    for (int k = 0; k < alig->originalNumberOfResidues; k++)
+      if (hits[k] >= ovrlap)
+        seqValue++;
+
+    // compute overlap of current sequence as the fraction of columns
+    // above overlap threshold
+    spuriousVector[i] = ((float)seqValue / alig->originalNumberOfResidues);
+  }
+
+  // free allocated memory
+  free(hits);
+  free(hits_u8);
+
+  // If there is not problem in the method, return true
+  return true;
+}
+
+template <class Vector> 
+inline void calculateSeqIdentity(statistics::Identity &id) {
+  int i, j, k, l;
+  const Alignment* alig = id.alig;
+
+  // create identities matrix to store identities scores
+  id.identities = new float *[alig->originalNumberOfSequences];
+  for (int i = 0; i < alig->originalNumberOfSequences; i++) {
+      if (alig->saveSequences[i] == -1)
+          continue;
+      id.identities[i] = new float[alig->originalNumberOfSequences];
+      id.identities[i][i] = 0;
+  }
+
+  // Depending on alignment type, indetermination symbol will be one or other
+  char indet = (alig->getAlignmentType() & SequenceTypes::AA) ? 'X' : 'N';
+
+  // prepare constant SIMD vectors
+  const Vector ALLINDET = Vector::duplicate(indet);
+  const Vector ALLGAP = Vector::duplicate('-');
+  const Vector ONES = Vector::duplicate(1);
+
+  // create an index of residues to skip
+  uint8_t *skipResidues = aligned_array<uint8_t, Vector>(
+      alig->originalNumberOfResidues); // ALIGNED_ALLOC(alig->originalNumberOfResidues,
+                                         // uint8_t);
+  for (int k = 0; k < alig->originalNumberOfResidues; k++) {
+    skipResidues[k] = alig->saveResidues[k] == -1 ? 0xFF : 0;
+  }
+
+  // For each seq, compute its identity score against the others in the MSA
+  for (i = 0; i < alig->originalNumberOfSequences; i++) {
+    if (alig->saveSequences[i] == -1)
+      continue;
+
+    const uint8_t *datai =
+        reinterpret_cast<const uint8_t *>(alig->sequences[i].data());
+
+    // Compute identity scores for the current sequence against the rest
+    for (j = i + 1; j < alig->originalNumberOfSequences; j++) {
+      if (alig->saveSequences[j] == -1)
+        continue;
+
+      const uint8_t *dataj =
+          reinterpret_cast<const uint8_t *>(alig->sequences[j].data());
+
+      Vector dst_acc = Vector();
+      Vector hit_acc = Vector();
+
+      int hit = 0;
+      int dst = 0;
+
+      // run with unrolled loops of UCHAR_MAX iterations first
+      for (k = 0; ((int)(k + Vector::LANES * UCHAR_MAX)) <
+                  alig->originalNumberOfResidues;) {
+        for (l = 0; l < UCHAR_MAX; l++, k += Vector::LANES) {
+          // load data for the sequences
+          Vector seqi = Vector::loadu(&datai[k]);
+          Vector seqj = Vector::loadu(&dataj[k]);
+          Vector skip = Vector::load(&skipResidues[k]);
+          Vector eq = (seqi == seqj);
+          // find which sequence characters are gap or indet
+          Vector gapsi = ((seqi == ALLGAP) | (seqi == ALLINDET));
+          Vector gapsj = ((seqj == ALLGAP) | (seqj == ALLINDET));
+          // find position where not both characters are gap
+          Vector mask = ONES.andnot(gapsi & gapsj).andnot(skip);
+          // update counters
+          dst_acc += mask;
+          hit_acc += (eq & mask);
+        }
+        // merge accumulators
+        dst += dst_acc.sum();
+        hit += hit_acc.sum();
+        dst_acc.clear();
+        hit_acc.clear();
+      }
+
+      // run remaining iterations in SIMD while possible
+      for (; ((int)(k + Vector::LANES)) < alig->originalNumberOfResidues;
+           k += Vector::LANES) {
+        // load data for the sequences; load is unaligned because
+        // string data is not guaranteed to be aligned.
+        Vector seqi = Vector::loadu(&datai[k]);
+        Vector seqj = Vector::loadu(&dataj[k]);
+        Vector skip = Vector::load(&skipResidues[k]);
+        Vector eq = (seqi == seqj);
+        // find which sequence characters are gap or indet
+        Vector gapsi = ((seqi == ALLGAP) | (seqi == ALLINDET));
+        Vector gapsj = ((seqj == ALLGAP) | (seqj == ALLINDET));
+        // find position where not both characters are gap
+        Vector mask = ONES.andnot(gapsi & gapsj).andnot(skip);
+        // update counters
+        dst_acc += mask;
+        hit_acc += (eq & mask);
+      }
+
+      // update counters after last loop
+      hit += hit_acc.sum();
+      dst += dst_acc.sum();
+
+      // process the tail elements when there remain less than
+      // can be fitted in a SIMD vector
+      for (; k < alig->originalNumberOfResidues; k++) {
+        int gapi = (datai[k] == indet) || (datai[k] == '-');
+        int gapj = (dataj[k] == indet) || (dataj[k] == '-');
+        dst += (!(gapi && gapj)) && (!skipResidues[k]);
+        hit +=
+            (!(gapi && gapj)) && (!skipResidues[k]) && (datai[k] == dataj[k]);
+      }
+
+      if (dst == 0) {
+        id.identities[i][j] = 0;
+      } else {
+        // Identity score between two sequences is the ratio of identical
+        // residues by the total length (common and no-common residues) among
+        // them
+        id.identities[i][j] = (float)hit / dst;
+      }
+
+      id.identities[j][i] = id.identities[i][j];
+    }
+  }
+
+  // free allocated memory
+  free(skipResidues);
+}
+
+template <class Vector> 
+inline void calculateGapVectors(statistics::Gaps &g) {
+  int i, j;
+  const Vector ALLGAP = Vector::duplicate('-');
+  const Vector ONES = Vector::duplicate(1);
+  const Alignment* alig = g.alig;
+
+
+  // use temporary buffer for storing 8-bit partial sums
+  uint8_t *gapsInColumn_u8 =
+      aligned_array<uint8_t, Vector>(alig->originalNumberOfResidues);
+  memset(g.gapsInColumn, 0, sizeof(int) * alig->originalNumberOfResidues);
+  memset(gapsInColumn_u8, 0,
+         sizeof(uint8_t) * alig->originalNumberOfResidues);
+
+  // count gaps per column
+  for (j = 0; j < alig->originalNumberOfSequences; j++) {
+    // skip sequences not retained in alignment
+    if (alig->saveSequences[j] == -1)
+      continue;
+    // process the whole sequence, 16 lanes at a time
+    const uint8_t *data =
+        reinterpret_cast<const uint8_t *>(alig->sequences[j].data());
+    for (i = 0; ((int)(i + Vector::LANES)) < alig->originalNumberOfResidues;
+         i += Vector::LANES) {
+      Vector letters = Vector::loadu(&data[i]);
+      Vector counts = Vector::load(&gapsInColumn_u8[i]);
+      counts += (ONES & (letters == ALLGAP));
+      counts.store(&gapsInColumn_u8[i]);
+    }
+    // count the remaining gap elements without SIMD
+    for (; i < alig->originalNumberOfResidues; i++)
+      if (data[i] == '-')
+        gapsInColumn_u8[i]++;
+    // every UCHAR_MAX iterations the accumulator may overflow, so the
+    // temporary counts are moved into the final counter array, and the
+    // accumulator is reset
+    if (j % UCHAR_MAX == 0) {
+      for (i = 0; i < alig->originalNumberOfResidues; i++)
+        g.gapsInColumn[i] += gapsInColumn_u8[i];
+      memset(gapsInColumn_u8, 0,
+             sizeof(uint8_t) * alig->originalNumberOfResidues);
+    }
+  }
+  // collect the remaining partial counts into the final counter array
+  for (i = 0; i < alig->originalNumberOfResidues; i++)
+    g.gapsInColumn[i] += gapsInColumn_u8[i];
+
+  // free temporary buffer
+  free(gapsInColumn_u8);
+
+  // build histogram and find largest number of gaps
+  for (int i = 0; i < alig->originalNumberOfResidues; i++) {
+    // g.totalGaps += g.gapsInColumn[i];
+    g.numColumnsWithGaps[g.gapsInColumn[i]]++;
+    if (g.gapsInColumn[i] > g.maxGaps)
+      g.maxGaps = g.gapsInColumn[i];
+  }
+}
+} // namespace simd
+
+#endif

--- a/include/Platform/template.h
+++ b/include/Platform/template.h
@@ -320,8 +320,6 @@ inline bool calculateSpuriousVector(statistics::Overlap &o, const float overlap,
   uint32_t ovrlap =
       uint32_t(ceil(overlap * float(alig->originalNumberOfSequences - 1)));
 
-
-
   // Depending on alignment type, indetermination symbol will be one or other
   char indet = (alig->getAlignmentType() & SequenceTypes::AA) ? 'X' : 'N';
 
@@ -343,6 +341,7 @@ inline bool calculateSpuriousVector(statistics::Overlap &o, const float overlap,
     memset(&hits[0], 0, alig->originalNumberOfResidues * sizeof(uint32_t));
     memset(&hits_u8[0], 0, alig->originalNumberOfResidues * sizeof(uint8_t));
 
+    unsigned int processedSequences = 0;
     const uint8_t *datai =
         reinterpret_cast<const uint8_t *>(alig->sequences[i].data());
 
@@ -390,11 +389,12 @@ inline bool calculateSpuriousVector(statistics::Overlap &o, const float overlap,
       // we can process up to UCHAR_MAX sequences, otherwise hits_u8[k]
       // may overflow, so every UCHAR_MAX iterations we transfer the
       // partial hit counts from `hits_u8` to `hits`
-      if ((j % UCHAR_MAX) == 0) {
+      if ((processedSequences % UCHAR_MAX) == 0) {
         for (k = 0; k < alig->originalNumberOfResidues; k++)
           hits[k] += hits_u8[k];
         memset(hits_u8, 0, alig->originalNumberOfResidues * sizeof(uint8_t));
       }
+      processedSequences++;
     }
 
     // update counters after last loop

--- a/include/Platform/x86/AVX2.h
+++ b/include/Platform/x86/AVX2.h
@@ -1,0 +1,75 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef TRIMAL_PLATFORM_X86_AVX2_H
+#define TRIMAL_PLATFORM_X86_AVX2_H
+
+#include "Statistics/Identity.h"
+#include "Statistics/Gaps.h"
+#include "Statistics/Overlap.h"
+#include "Statistics/Similarity.h"
+
+namespace statistics {
+
+class AVX2Similarity : public Similarity {
+public:
+  AVX2Similarity(Alignment *parentAlignment) : Similarity(parentAlignment) {}
+  AVX2Similarity(Alignment *parentAlignment, Similarity *parentSimilarity) :
+    Similarity(parentAlignment, parentSimilarity) {}
+  void calculateMatrixIdentity() override;
+  bool calculateVectors(bool cutByGap) override;
+};
+class AVX2Gaps : public Gaps {
+public:
+  AVX2Gaps(Alignment *parentAlignment) : Gaps(parentAlignment) {}
+  AVX2Gaps(Alignment *parentAlignment, Gaps *parentGaps):
+    Gaps(parentAlignment, parentGaps) {}
+  void CalculateVectors() override;
+};
+
+class AVX2Overlap : public Overlap {
+public:
+  AVX2Overlap(Alignment *parent) : Overlap(parent) {}
+  AVX2Overlap(Alignment *parent, Overlap *parentOverlap) : Overlap(parent, parentOverlap) {}
+  bool calculateSpuriousVector(float overlap, float *spuriousVector) override;
+};
+
+class AVX2Identity : public Identity {
+public:
+  AVX2Identity(Alignment *parent) : Identity(parent) {}
+  AVX2Identity(Alignment *parent, Identity *parentIdentity) : Identity(parent, parentIdentity) {}
+  void calculateSeqIdentity() override;
+};
+
+} // namespace statistics
+
+#endif

--- a/include/Platform/x86/SSE2.h
+++ b/include/Platform/x86/SSE2.h
@@ -1,0 +1,75 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#ifndef TRIMAL_PLATFORM_X86_SSE2_H
+#define TRIMAL_PLATFORM_X86_SSE2_H
+
+#include "Statistics/Identity.h"
+#include "Statistics/Gaps.h"
+#include "Statistics/Overlap.h"
+#include "Statistics/Similarity.h"
+
+namespace statistics {
+
+class SSE2Similarity : public Similarity {
+public:
+  SSE2Similarity(Alignment *parentAlignment) : Similarity(parentAlignment) {}
+  SSE2Similarity(Alignment *parentAlignment, Similarity *parentSimilarity) :
+    Similarity(parentAlignment, parentSimilarity) {}
+  void calculateMatrixIdentity() override;
+  bool calculateVectors(bool cutByGap) override;
+};
+class SSE2Gaps : public Gaps {
+public:
+  SSE2Gaps(Alignment *parentAlignment) : Gaps(parentAlignment) {}
+  SSE2Gaps(Alignment *parentAlignment, Gaps *parentGaps):
+    Gaps(parentAlignment, parentGaps) {}
+  void CalculateVectors() override;
+};
+
+class SSE2Overlap : public Overlap {
+public:
+  SSE2Overlap(Alignment *parent) : Overlap(parent) {}
+  SSE2Overlap(Alignment *parent, Overlap *parentOverlap) : Overlap(parent, parentOverlap) {}
+  bool calculateSpuriousVector(float overlap, float *spuriousVector) override;
+};
+
+class SSE2Identity : public Identity {
+public:
+  SSE2Identity(Alignment *parent) : Identity(parent) {}
+  SSE2Identity(Alignment *parent, Identity *parentIdentity) : Identity(parent, parentIdentity) {}
+  void calculateSeqIdentity() override;
+};
+
+} // namespace statistics
+
+#endif

--- a/include/Statistics/Gaps.h
+++ b/include/Statistics/Gaps.h
@@ -60,7 +60,7 @@ namespace statistics {
         explicit Gaps(Alignment *parent);
 
         // Class destroyer.
-        ~Gaps();
+        virtual ~Gaps();
 
         // Methods allows us compute the gapWindows' values.
         bool applyWindow(int);
@@ -89,7 +89,7 @@ namespace statistics {
 
         bool isDefinedWindow();
 
-        void CalculateVectors();
+        virtual void CalculateVectors();
     };
 }
 #endif

--- a/include/Statistics/Identity.h
+++ b/include/Statistics/Identity.h
@@ -60,7 +60,7 @@ namespace statistics {
         explicit Identity(Alignment* parentAlignment);
 
         /** \brief Destructor */
-        ~Identity();
+        virtual ~Identity();
 
         /**
         \brief Method to calculate identities between the sequences from the alignment.\n

--- a/include/Statistics/Identity.h
+++ b/include/Statistics/Identity.h
@@ -65,14 +65,14 @@ namespace statistics {
         /**
         \brief Method to calculate identities between the sequences from the alignment.\n
         */
-        void calculateSeqIdentity();
+        virtual void calculateSeqIdentity();
 
         /**
         \warning Not In Use
         \brief Method that makes a raw approximation of sequence identity computation.\n
         \note Designed for reducing comparisons for huge alignments.
         */
-        void calculateRelaxedSeqIdentity();
+        virtual void calculateRelaxedSeqIdentity();
     };
 }
 

--- a/include/Statistics/Identity.h
+++ b/include/Statistics/Identity.h
@@ -72,7 +72,7 @@ namespace statistics {
         \brief Method that makes a raw approximation of sequence identity computation.\n
         \note Designed for reducing comparisons for huge alignments.
         */
-        virtual void calculateRelaxedSeqIdentity();
+        void calculateRelaxedSeqIdentity();
     };
 }
 

--- a/include/Statistics/Overlap.h
+++ b/include/Statistics/Overlap.h
@@ -65,7 +65,7 @@ namespace statistics {
         /**
         \brief Method to calculate overlap between the sequences from the alignment.\n
         */
-        void calculateSeqOverlap();
+        virtual void calculateSeqOverlap();
 
         /**
         \brief Method to compute the overlap values.\n
@@ -77,7 +77,7 @@ namespace statistics {
                     <b> False </b> otherwise.\n
         This should happen only if you pass a null pointer instead of a spuriousVector.
         */
-        bool calculateSpuriousVector(float overlapColumn, float *spuriousVector);
+        virtual bool calculateSpuriousVector(float overlapColumn, float *spuriousVector);
     };
 }
 

--- a/include/Statistics/Overlap.h
+++ b/include/Statistics/Overlap.h
@@ -60,7 +60,7 @@ namespace statistics {
         explicit Overlap(Alignment* parentAlignment);
 
         /** \brief Destructor */
-        ~Overlap();
+        virtual ~Overlap();
 
         /**
         \brief Method to calculate overlap between the sequences from the alignment.\n

--- a/include/Statistics/Similarity.h
+++ b/include/Statistics/Similarity.h
@@ -114,7 +114,7 @@ namespace statistics {
             \param sm Similarity matrix pointer to associate.
             \return \b True if sm is valid, \b False if it's null
         */
-        virtual bool setSimilarityMatrix(similarityMatrix * sm);
+        bool setSimilarityMatrix(similarityMatrix * sm);
 
         /**
             \brief Returns if a similarity matrix is being used or not.

--- a/include/Statistics/Similarity.h
+++ b/include/Statistics/Similarity.h
@@ -76,19 +76,19 @@ namespace statistics {
 
     public:
         /** \brief Computes the matrix identity between alignment's columns. */
-        void calculateMatrixIdentity();
+        virtual void calculateMatrixIdentity();
 
         /** \brief Constructor without any parameters */
         explicit Similarity(Alignment * parentAlignment);
 
         /** \brief Destructor */
-        ~Similarity();
+        virtual ~Similarity();
 
         /**
             \brief Method to calculate the similarity values of a alignment matrix.
             \param cutByGap Wheter to cut by gap or not
         */
-        bool calculateVectors(bool cutByGap = true);
+        virtual bool calculateVectors(bool cutByGap = true);
 
         /**
             \brief Allows us compute the conservationWindow's values.
@@ -114,7 +114,7 @@ namespace statistics {
             \param sm Similarity matrix pointer to associate.
             \return \b True if sm is valid, \b False if it's null
         */
-        bool setSimilarityMatrix(similarityMatrix * sm);
+        virtual bool setSimilarityMatrix(similarityMatrix * sm);
 
         /**
             \brief Returns if a similarity matrix is being used or not.

--- a/include/Statistics/similarityMatrix.h
+++ b/include/Statistics/similarityMatrix.h
@@ -49,6 +49,7 @@ namespace statistics {
  */
     class similarityMatrix {
 
+    private:
         int *vhash;
         float **simMat;
         float **distMat;
@@ -122,6 +123,16 @@ namespace statistics {
          * \brief Method to print the loaded matrix.
         */
         void printMatrix();
+
+        /**
+         * \brief Get the index of a letter inside the distance matrix.
+        */
+        const int getLetterIndex(char letter) { return this->vhash[letter - 'A']; }
+
+        /**
+         * \brief Get a read-only view over the matrix content.
+        */
+        const float** getDistanceMatrix() { return const_cast<const float**>(this->distMat); }
     };
 }
 #endif

--- a/scripts/CMake/FindAVX2.cmake
+++ b/scripts/CMake/FindAVX2.cmake
@@ -1,0 +1,311 @@
+#.rst:
+# FindAVX2
+# --------
+#
+# Finds AVX2 support
+#
+# This module can be used to detect AVX2 support in a C compiler.  If
+# the compiler supports AVX2, the flags required to compile with
+# AVX2 support are returned in variables for the different languages.
+# The variables may be empty if the compiler does not need a special
+# flag to support AVX2.
+#
+# The following variables are set:
+#
+# ::
+#
+#    AVX2_C_FLAGS - flags to add to the C compiler for AVX2 support
+#    AVX2_FOUND - true if AVX2 is detected
+#
+#=============================================================================
+
+set(_AVX2_REQUIRED_VARS)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${AVX2_FIND_QUIETLY})
+
+# sample AVX2 source code to test
+set(AVX2_C_TEST_SOURCE
+"
+#include <immintrin.h>
+void parasail_memset___m256i(__m256i *b, __m256i c, size_t len)
+{
+    size_t i;
+    for (i=0; i<len; ++i) {
+        _mm256_store_si256(&b[i], c);
+    }
+}
+int foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    __m256i result =  _mm256_add_epi8(vOne,vOne);
+    return _mm_extract_epi16(_mm256_extracti128_si256(result,0),0);
+}
+int main(void) { return (int)foo(); }
+")
+
+# if these are set then do not try to find them again,
+# by avoiding any try_compiles for the flags
+if((DEFINED AVX2_C_FLAGS) OR (DEFINED HAVE_AVX2))
+else()
+  if(WIN32)
+    # MSVC can compile AVX intrinsics without the arch flag, however it
+    # will detect that AVX code is found and "consider using /arch:AVX".
+    set(AVX2_C_FLAG_CANDIDATES
+      "/arch:AVX"
+      "/arch:AVX2")
+  else()
+    set(AVX2_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts AVX2
+      " "
+      #GNU, Intel
+      "-march=core-avx2"
+      #clang
+      "-mavx2"
+    )
+  endif()
+
+  include(CheckCSourceCompiles)
+
+  foreach(FLAG IN LISTS AVX2_C_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(HAVE_AVX2 CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try AVX2 C flag = [${FLAG}]")
+    endif()
+    check_c_source_compiles("${AVX2_C_TEST_SOURCE}" HAVE_AVX2)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(HAVE_AVX2)
+      set(AVX2_C_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  unset(AVX2_C_FLAG_CANDIDATES)
+  
+  set(AVX2_C_FLAGS "${AVX2_C_FLAGS_INTERNAL}"
+    CACHE STRING "C compiler flags for AVX2 intrinsics")
+endif()
+
+list(APPEND _AVX2_REQUIRED_VARS AVX2_C_FLAGS)
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+if(_AVX2_REQUIRED_VARS)
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(AVX2
+                                    REQUIRED_VARS ${_AVX2_REQUIRED_VARS})
+
+  mark_as_advanced(${_AVX2_REQUIRED_VARS})
+
+  unset(_AVX2_REQUIRED_VARS)
+else()
+  message(SEND_ERROR "FindAVX2 requires C or CXX language to be enabled")
+endif()
+
+# begin tests for AVX2 specfic features
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(SAFE_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(SAFE_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+
+set(AVX2_C_TEST_SOURCE_SET1_EPI64X
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi64x(1);
+    return vOne;
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_SET1_EPI64X}" HAVE_AVX2_MM256_SET1_EPI64X)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_SET_EPI64X
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set_epi64x(1,1,1,1);
+    return vOne;
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_SET_EPI64X}" HAVE_AVX2_MM256_SET_EPI64X)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT64
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi64(vOne,INT64_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT64}" HAVE_AVX2_MM256_INSERT_EPI64)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT32
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi32(vOne,INT32_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT32}" HAVE_AVX2_MM256_INSERT_EPI32)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT16
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi16(vOne,INT16_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT16}" HAVE_AVX2_MM256_INSERT_EPI16)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT8
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi8(vOne,INT8_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT8}" HAVE_AVX2_MM256_INSERT_EPI8)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+
+set(AVX2_C_TEST_SOURCE_EXTRACT64
+"
+#include <stdint.h>
+#include <immintrin.h>
+int64_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int64_t)_mm256_extract_epi64(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT64}" HAVE_AVX2_MM256_EXTRACT_EPI64)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT32
+"
+#include <stdint.h>
+#include <immintrin.h>
+int32_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int32_t)_mm256_extract_epi32(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT32}" HAVE_AVX2_MM256_EXTRACT_EPI32)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT16
+"
+#include <stdint.h>
+#include <immintrin.h>
+int16_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int16_t)_mm256_extract_epi16(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT16}" HAVE_AVX2_MM256_EXTRACT_EPI16)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT8
+"
+#include <stdint.h>
+#include <immintrin.h>
+int8_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int8_t)_mm256_extract_epi8(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT8}" HAVE_AVX2_MM256_EXTRACT_EPI8)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_C_FLAGS "${SAFE_CMAKE_C_FLAGS}")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${SAFE_CMAKE_C_FLAGS}")
+endif()

--- a/scripts/CMake/FindAVX2.cmake
+++ b/scripts/CMake/FindAVX2.cmake
@@ -56,10 +56,10 @@ else()
     set(AVX2_C_FLAG_CANDIDATES
       #Empty, if compiler automatically accepts AVX2
       " "
-      #GNU, Intel
-      "-march=core-avx2"
       #clang
       "-mavx2"
+      #GNU, Intel
+      "-march=core-avx2"
     )
   endif()
 

--- a/scripts/CMake/FindNEON.cmake
+++ b/scripts/CMake/FindNEON.cmake
@@ -1,0 +1,97 @@
+#.rst:
+# FindNEON
+# --------
+#
+# Finds NEON support
+#
+# This module can be used to detect NEON support in a C compiler.  If
+# the compiler supports NEON, the flags required to compile with
+# NEON support are returned in variables for the different languages.
+# The variables may be empty if the compiler does not need a special
+# flag to support NEON.
+#
+# The following variables are set:
+#
+# ::
+#
+#    NEON_C_FLAGS - flags to add to the C compiler for NEON support
+#    NEON_FOUND - true if NEON is detected
+#
+#=============================================================================
+
+set(_NEON_REQUIRED_VARS)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${NEON_FIND_QUIETLY})
+
+# sample NEON source code to test
+set(NEON_C_TEST_SOURCE
+"
+#include <arm_neon.h>
+uint32x4_t double_elements(uint32x4_t input)
+{
+    return(vaddq_u32(input, input));
+}
+int main(void)
+{
+    uint32x4_t one;
+    uint32x4_t two = double_elements(one);
+    return 0;
+}
+")
+
+# if these are set then do not try to find them again,
+# by avoiding any try_compiles for the flags
+if((DEFINED NEON_C_FLAGS) OR (DEFINED HAVE_NEON))
+else()
+  if(WIN32)
+    set(NEON_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts NEON
+      " ")
+  else()
+    set(NEON_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts NEON
+      " "
+      "-mfpu=neon"
+      "-mfpu=neon -mfloat-abi=softfp"
+    )
+  endif()
+
+  include(CheckCSourceCompiles)
+
+  foreach(FLAG IN LISTS NEON_C_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(HAVE_NEON CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try NEON C flag = [${FLAG}]")
+    endif()
+    check_c_source_compiles("${NEON_C_TEST_SOURCE}" HAVE_NEON)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(HAVE_NEON)
+      set(NEON_C_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  unset(NEON_C_FLAG_CANDIDATES)
+  
+  set(NEON_C_FLAGS "${NEON_C_FLAGS_INTERNAL}"
+    CACHE STRING "C compiler flags for NEON intrinsics")
+endif()
+
+list(APPEND _NEON_REQUIRED_VARS NEON_C_FLAGS)
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+if(_NEON_REQUIRED_VARS)
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(NEON
+                                    REQUIRED_VARS ${_NEON_REQUIRED_VARS})
+
+  mark_as_advanced(${_NEON_REQUIRED_VARS})
+
+  unset(_NEON_REQUIRED_VARS)
+else()
+  message(SEND_ERROR "FindNEON requires C or CXX language to be enabled")
+endif()

--- a/scripts/CMake/FindSSE2.cmake
+++ b/scripts/CMake/FindSSE2.cmake
@@ -52,10 +52,10 @@ else()
     set(SSE2_C_FLAG_CANDIDATES
       #Empty, if compiler automatically accepts SSE2
       " "
-      #GNU, Intel
-      "-march=core2"
       #clang
       "-msse2"
+      #GNU, Intel
+      "-march=core2"
     )
   endif()
 

--- a/scripts/CMake/FindSSE2.cmake
+++ b/scripts/CMake/FindSSE2.cmake
@@ -1,0 +1,100 @@
+#.rst:
+# FindSSE2
+# --------
+#
+# Finds SSE2 support
+#
+# This module can be used to detect SSE2 support in a C compiler.  If
+# the compiler supports SSE2, the flags required to compile with
+# SSE2 support are returned in variables for the different languages.
+# The variables may be empty if the compiler does not need a special
+# flag to support SSE2.
+#
+# The following variables are set:
+#
+# ::
+#
+#    SSE2_C_FLAGS - flags to add to the C compiler for SSE2 support
+#    SSE2_FOUND - true if SSE2 is detected
+#
+#=============================================================================
+
+set(_SSE2_REQUIRED_VARS)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${SSE2_FIND_QUIETLY})
+
+# sample SSE2 source code to test
+set(SSE2_C_TEST_SOURCE
+"
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
+#include <emmintrin.h>
+#endif
+int foo() {
+    __m128i vOne = _mm_set1_epi16(1);
+    __m128i result = _mm_add_epi16(vOne,vOne);
+    return _mm_extract_epi16(result, 0);
+}
+int main(void) { return foo(); }
+")
+
+# if these are set then do not try to find them again,
+# by avoiding any try_compiles for the flags
+if((DEFINED SSE2_C_FLAGS) OR (DEFINED HAVE_SSE2))
+else()
+  if(WIN32)
+    set(SSE2_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts SSE2
+      " "
+      "/arch:SSE2")
+  else()
+    set(SSE2_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts SSE2
+      " "
+      #GNU, Intel
+      "-march=core2"
+      #clang
+      "-msse2"
+    )
+  endif()
+
+  include(CheckCSourceCompiles)
+
+  foreach(FLAG IN LISTS SSE2_C_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(HAVE_SSE2 CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try SSE2 C flag = [${FLAG}]")
+    endif()
+    check_c_source_compiles("${SSE2_C_TEST_SOURCE}" HAVE_SSE2)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(HAVE_SSE2)
+      set(SSE2_C_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  unset(SSE2_C_FLAG_CANDIDATES)
+
+  set(SSE2_C_FLAGS "${SSE2_C_FLAGS_INTERNAL}"
+    CACHE STRING "C compiler flags for SSE2 intrinsics")
+endif()
+
+list(APPEND _SSE2_REQUIRED_VARS SSE2_C_FLAGS)
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+if(_SSE2_REQUIRED_VARS)
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(SSE2
+                                    REQUIRED_VARS ${_SSE2_REQUIRED_VARS})
+
+  mark_as_advanced(${_SSE2_REQUIRED_VARS})
+
+  unset(_SSE2_REQUIRED_VARS)
+else()
+  message(SEND_ERROR "FindSSE2 requires C or CXX language to be enabled")
+endif()

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -79,3 +79,13 @@ if (HAVE_AVX2)
     target_compile_options(AVX2OBJLib PRIVATE "${AVX2_C_FLAGS}")
   endif()
 endif()
+
+# NEON
+if (HAVE_NEON)
+  message(STATUS "Detected compiler support for AVX2 CPU extensions.")
+  add_compile_definitions(HAVE_NEON=1)
+  add_library(NEONOBJLib OBJECT source/Platform/Arm/NEON.cpp)
+  if(NOT NEON_C_FLAGS STREQUAL " ")
+    target_compile_options(NEONOBJLib PRIVATE "${NEON_C_FLAGS}")
+  endif()
+endif()

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -82,7 +82,7 @@ endif()
 
 # NEON
 if (HAVE_NEON)
-  message(STATUS "Detected compiler support for AVX2 CPU extensions.")
+  message(STATUS "Detected compiler support for NEON CPU extensions.")
   add_compile_definitions(HAVE_NEON=1)
   add_library(NEONOBJLib OBJECT source/Platform/Arm/NEON.cpp)
   if(NOT NEON_C_FLAGS STREQUAL " ")

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -60,3 +60,12 @@ add_library(TestsOBJLib             OBJECT ${tests})
 SET_TARGET_PROPERTIES(CatchOBJLib PROPERTIES EXCLUDE_FROM_ALL True)
 SET_TARGET_PROPERTIES(TestsOBJLib PROPERTIES EXCLUDE_FROM_ALL True)
 
+# SSE2
+if (HAVE_SSE2)
+  message(STATUS "Detected compiler support for SSE2 CPU extensions.")
+  add_compile_definitions(HAVE_SSE2=1)
+  add_library(SSE2OBJLib OBJECT source/Platform/x86/SSE2.cpp)
+  if(NOT SSE2_C_FLAGS STREQUAL " ")
+    target_compile_options(SSE2OBJLib PRIVATE "${SSE2_C_FLAGS}")
+  endif()
+endif()

--- a/scripts/CMake/OBJ-LIB-creator.cmake
+++ b/scripts/CMake/OBJ-LIB-creator.cmake
@@ -69,3 +69,13 @@ if (HAVE_SSE2)
     target_compile_options(SSE2OBJLib PRIVATE "${SSE2_C_FLAGS}")
   endif()
 endif()
+
+# AVX2
+if (HAVE_AVX2)
+  message(STATUS "Detected compiler support for AVX2 CPU extensions.")
+  add_compile_definitions(HAVE_AVX2=1)
+  add_library(AVX2OBJLib OBJECT source/Platform/x86/AVX2.cpp)
+  if(NOT AVX2_C_FLAGS STREQUAL " ")
+    target_compile_options(AVX2OBJLib PRIVATE "${AVX2_C_FLAGS}")
+  endif()
+endif()

--- a/source/Platform/Arm/NEON.cpp
+++ b/source/Platform/Arm/NEON.cpp
@@ -1,0 +1,141 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#include <arm_neon.h>
+#include <climits>
+#include <cstdint>
+
+#include "Alignment/Alignment.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Manager.h"
+#include "Statistics/Similarity.h"
+#include "Platform/Arm/NEON.h"
+#include "Platform/template.h"
+#include "defines.h"
+#include "reportsystem.h"
+#include "utils.h"
+
+
+class NEONVector {
+private:
+  uint8x16_t vector;
+  inline NEONVector(uint8x16_t vec) : vector(vec) {}
+
+public:
+  const static size_t LANES = 16;
+  const static size_t SIZE = sizeof(uint8x16_t);
+
+  inline NEONVector() : vector(vdupq_n_u8(0)) {}
+
+  inline static NEONVector duplicate(const uint8_t value) {
+    return NEONVector(vdupq_n_u8(value));
+  }
+
+  inline static NEONVector load(const uint8_t *data) {
+    return NEONVector(vld1q_u8(data));
+  }
+
+  inline static NEONVector loadu(const uint8_t *data) {
+    return NEONVector(vld1q_u8(data));
+  }
+
+  inline void store(uint8_t *data) const { vst1q_u8(data, vector); }
+
+  inline void storeu(uint8_t *data) const { vst1q_u8(data, vector); }
+
+  inline NEONVector &operator+=(const NEONVector &rhs) {
+    vector = vaddq_u8(vector, rhs.vector);
+    return *this;
+  }
+
+  inline NEONVector operator==(const NEONVector &rhs) const {
+    return NEONVector(vceqq_u8(vector, rhs.vector));
+  }
+
+  inline NEONVector operator&(const NEONVector &rhs) const {
+    return NEONVector(vandq_u8(vector, rhs.vector));
+  }
+
+  inline NEONVector operator|(const NEONVector &rhs) const {
+    return NEONVector(vorrq_u8(vector, rhs.vector));
+  }
+
+  inline NEONVector operator!() const { return NEONVector(vmvnq_u8(vector)); }
+
+  inline NEONVector andnot(const NEONVector &rhs) const {
+    return NEONVector(vbicq_u8(vector, rhs.vector));
+  }
+
+  inline uint16_t sum() const {
+#ifdef __aarch64__
+    // Don't use `vaddvq_u8` because it can overflow, first add pairwise
+    // into 16-bit lanes to avoid overflows
+    return vaddvq_u16(vpaddlq_u8(vector));
+#else
+    uint64x2_t paired = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vector)));
+    return vgetq_lane_u64(paired, 0) + vgetq_lane_u64(paired, 1);
+#endif
+  }
+
+  inline void clear() { vector = vdupq_n_u8(0); }
+};
+
+namespace statistics {
+
+void NEONSimilarity::calculateMatrixIdentity() {
+  StartTiming("void NEONSimilarity::calculateMatrixIdentity() ");
+  simd::calculateMatrixIdentity<NEONVector>(*this);
+}
+
+bool NEONSimilarity::calculateVectors(bool cutByGap) {
+  StartTiming("bool NEONSimilarity::calculateVectors(bool cutByGap) ");
+  return simd::calculateSimilarityVectors<NEONVector>(*this, cutByGap);
+}
+
+void NEONGaps::CalculateVectors() {
+  StartTiming("bool NEONGaps::CalculateVectors() ");
+  simd::calculateGapVectors<NEONVector>(*this);
+}
+
+void NEONIdentity::calculateSeqIdentity() {
+  StartTiming("void NEONIdentity::calculateSeqIdentity() ");
+  simd::calculateSeqIdentity<NEONVector>(*this);
+}
+
+bool NEONOverlap::calculateSpuriousVector(float overlap, float *spuriousVector) {
+  StartTiming("bool NEONOverlap::calculateSpuriousVector(float overlap, float "
+              "*spuriousVector) ");
+  return simd::calculateSpuriousVector<NEONVector>(*this, overlap,
+                                                  spuriousVector);
+}
+
+} // namespace statistics

--- a/source/Platform/x86/AVX2.cpp
+++ b/source/Platform/x86/AVX2.cpp
@@ -1,0 +1,144 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#include <climits>
+#include <cstdint>
+#include <immintrin.h>
+
+#include "Alignment/Alignment.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Gaps.h"
+#include "Statistics/Manager.h"
+#include "Statistics/Similarity.h"
+#include "Platform/x86/AVX2.h"
+#include "Platform/template.h"
+#include "defines.h"
+#include "reportsystem.h"
+#include "utils.h"
+
+
+class AVX2Vector {
+private:
+  __m256i vector;
+  inline AVX2Vector(__m256i vec) : vector(vec) {}
+
+public:
+  const static size_t LANES = 32;
+  const static size_t SIZE = sizeof(__m256i);
+
+  inline AVX2Vector() : vector(_mm256_setzero_si256()) {}
+
+  inline static AVX2Vector duplicate(const uint8_t value) {
+    return AVX2Vector(_mm256_set1_epi8(value));
+  }
+
+  inline static AVX2Vector load(const uint8_t *data) {
+    return AVX2Vector(_mm256_load_si256((const __m256i *)data));
+  }
+
+  inline static AVX2Vector loadu(const uint8_t *data) {
+    return AVX2Vector(_mm256_loadu_si256((const __m256i *)data));
+  }
+
+  inline void store(uint8_t *data) const {
+    _mm256_store_si256((__m256i *)data, vector);
+  }
+
+  inline void storeu(uint8_t *data) const {
+    _mm256_storeu_si256((__m256i *)data, vector);
+  }
+
+  inline AVX2Vector &operator+=(const AVX2Vector &rhs) {
+    vector = _mm256_add_epi8(vector, rhs.vector);
+    return *this;
+  }
+
+  inline AVX2Vector operator==(const AVX2Vector &rhs) const {
+    return AVX2Vector(_mm256_cmpeq_epi8(vector, rhs.vector));
+  }
+
+  inline AVX2Vector operator&(const AVX2Vector &rhs) const {
+    return AVX2Vector(_mm256_and_si256(vector, rhs.vector));
+  }
+
+  inline AVX2Vector operator|(const AVX2Vector &rhs) const {
+    return AVX2Vector(_mm256_or_si256(vector, rhs.vector));
+  }
+
+  inline AVX2Vector operator!() const {
+    return AVX2Vector(_mm256_andnot_si256(vector, _mm256_set1_epi8(0xFF)));
+  }
+
+  inline AVX2Vector andnot(const AVX2Vector &rhs) const {
+    return AVX2Vector(_mm256_andnot_si256(rhs.vector, vector));
+  }
+
+  inline uint16_t sum() const {
+    __m256i sum256 = _mm256_sad_epu8(vector, _mm256_setzero_si256());
+    __m128i sum128 = _mm_add_epi64(_mm256_extractf128_si256(sum256, 1), _mm256_castsi256_si128(sum256));
+    return _mm_extract_epi64(sum128, 0) + _mm_extract_epi64(sum128, 1);
+  }
+
+  inline void clear() { vector = _mm256_setzero_si256(); }
+};
+
+namespace statistics {
+
+void AVX2Similarity::calculateMatrixIdentity() {
+  StartTiming("void AVX2Similarity::calculateMatrixIdentity() ");
+  simd::calculateMatrixIdentity<AVX2Vector>(*this);
+}
+
+bool AVX2Similarity::calculateVectors(bool cutByGap) {
+  StartTiming("bool AVX2Similarity::calculateVectors(bool cutByGap) ");
+  return simd::calculateSimilarityVectors<AVX2Vector>(*this, cutByGap);
+}
+
+void AVX2Gaps::CalculateVectors() {
+  StartTiming("bool AVX2Gaps::CalculateVectors() ");
+  simd::calculateGapVectors<AVX2Vector>(*this);
+}
+
+void AVX2Identity::calculateSeqIdentity() {
+  StartTiming("void AVX2Identity::calculateSeqIdentity() ");
+  simd::calculateSeqIdentity<AVX2Vector>(*this);
+}
+
+bool AVX2Overlap::calculateSpuriousVector(float overlap, float *spuriousVector) {
+  StartTiming("bool AVX2Overlap::calculateSpuriousVector(float overlap, float "
+              "*spuriousVector) ");
+  return simd::calculateSpuriousVector<AVX2Vector>(*this, overlap,
+                                                  spuriousVector);
+}
+
+} // namespace statistics
+

--- a/source/Platform/x86/SSE2.cpp
+++ b/source/Platform/x86/SSE2.cpp
@@ -128,12 +128,12 @@ void SSE2Gaps::CalculateVectors() {
 }
 
 void SSE2Identity::calculateSeqIdentity() {
-  StartTiming("void SSE2Cleaner::calculateSeqIdentity() ");
+  StartTiming("void SSE2Identity::calculateSeqIdentity() ");
   simd::calculateSeqIdentity<SSE2Vector>(*this);
 }
 
 bool SSE2Overlap::calculateSpuriousVector(float overlap, float *spuriousVector) {
-  StartTiming("bool SSE2Cleaner::calculateSpuriousVector(float overlap, float "
+  StartTiming("bool SSE2Overlap::calculateSpuriousVector(float overlap, float "
               "*spuriousVector) ");
   return simd::calculateSpuriousVector<SSE2Vector>(*this, overlap,
                                                   spuriousVector);

--- a/source/Platform/x86/SSE2.cpp
+++ b/source/Platform/x86/SSE2.cpp
@@ -1,0 +1,142 @@
+/* *****************************************************************************
+
+    trimAl v2.0: a tool for automated alignment trimming in large-scale
+                 phylogenetics analyses.
+
+    readAl v2.0: a tool for automated alignment conversion among different
+                 formats.
+
+    2022-2023
+        Larralde, M.            (martin.larralde@embl.de)
+
+    2009-2019
+        Fernandez-Rodriguez V.  (victor.fernandez@bsc.es)
+        Capella-Gutierrez S.    (salvador.capella@bsc.es)
+        Gabaldon, T.            (tgabaldon@crg.es)
+
+    This file is part of trimAl/readAl.
+
+    trimAl/readAl are free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, the last available version.
+
+    trimAl/readAl are distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with trimAl/readAl. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************** */
+
+#include <climits>
+#include <cstdint>
+#include <emmintrin.h>
+
+#include "Alignment/Alignment.h"
+#include "InternalBenchmarker.h"
+#include "Statistics/Gaps.h"
+#include "Statistics/Manager.h"
+#include "Statistics/Similarity.h"
+#include "Platform/x86/SSE2.h"
+#include "Platform/template.h"
+#include "defines.h"
+#include "reportsystem.h"
+#include "utils.h"
+
+
+class SSE2Vector {
+private:
+  __m128i vector;
+  inline SSE2Vector(__m128i vec) : vector(vec) {}
+
+public:
+  const static size_t LANES = 16;
+  const static size_t SIZE = sizeof(__m128i);
+
+  inline SSE2Vector() : vector(_mm_setzero_si128()) {}
+
+  inline static SSE2Vector duplicate(const uint8_t value) {
+    return SSE2Vector(_mm_set1_epi8(value));
+  }
+
+  inline static SSE2Vector load(const uint8_t *data) {
+    return SSE2Vector(_mm_load_si128((const __m128i *)data));
+  }
+
+  inline static SSE2Vector loadu(const uint8_t *data) {
+    return SSE2Vector(_mm_loadu_si128((const __m128i *)data));
+  }
+
+  inline void store(uint8_t *data) const {
+    _mm_store_si128((__m128i *)data, vector);
+  }
+
+  inline void storeu(uint8_t *data) const {
+    _mm_storeu_si128((__m128i *)data, vector);
+  }
+
+  inline SSE2Vector &operator+=(const SSE2Vector &rhs) {
+    vector = _mm_add_epi8(vector, rhs.vector);
+    return *this;
+  }
+
+  inline SSE2Vector operator==(const SSE2Vector &rhs) const {
+    return SSE2Vector(_mm_cmpeq_epi8(vector, rhs.vector));
+  }
+
+  inline SSE2Vector operator&(const SSE2Vector &rhs) const {
+    return SSE2Vector(_mm_and_si128(vector, rhs.vector));
+  }
+
+  inline SSE2Vector operator|(const SSE2Vector &rhs) const {
+    return SSE2Vector(_mm_or_si128(vector, rhs.vector));
+  }
+
+  inline SSE2Vector operator!() const {
+    return SSE2Vector(_mm_andnot_si128(vector, _mm_set1_epi8(0xFF)));
+  }
+
+  inline SSE2Vector andnot(const SSE2Vector &rhs) const {
+    return SSE2Vector(_mm_andnot_si128(rhs.vector, vector));
+  }
+
+  inline uint16_t sum() const {
+    __m128i vsum = _mm_sad_epu8(vector, _mm_setzero_si128());
+    return _mm_extract_epi16(vsum, 0) + _mm_extract_epi16(vsum, 4);
+  }
+
+  inline void clear() { vector = _mm_setzero_si128(); }
+};
+
+namespace statistics {
+
+void SSE2Similarity::calculateMatrixIdentity() {
+  StartTiming("void SSE2Similarity::calculateMatrixIdentity() ");
+  simd::calculateMatrixIdentity<SSE2Vector>(*this);
+}
+
+bool SSE2Similarity::calculateVectors(bool cutByGap) {
+  StartTiming("bool SSE2Similarity::calculateVectors(bool cutByGap) ");
+  return simd::calculateSimilarityVectors<SSE2Vector>(*this, cutByGap);
+}
+
+void SSE2Gaps::CalculateVectors() {
+  StartTiming("bool SSE2Gaps::CalculateVectors() ");
+  simd::calculateGapVectors<SSE2Vector>(*this);
+}
+
+void SSE2Identity::calculateSeqIdentity() {
+  StartTiming("void SSE2Cleaner::calculateSeqIdentity() ");
+  simd::calculateSeqIdentity<SSE2Vector>(*this);
+}
+
+bool SSE2Overlap::calculateSpuriousVector(float overlap, float *spuriousVector) {
+  StartTiming("bool SSE2Cleaner::calculateSpuriousVector(float overlap, float "
+              "*spuriousVector) ");
+  return simd::calculateSpuriousVector<SSE2Vector>(*this, overlap,
+                                                  spuriousVector);
+}
+
+} // namespace statistics

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -331,7 +331,7 @@ namespace statistics {
 #elif defined(HAVE_SSE2)
             identity = new SSE2Identity(parent, mold->identity);
 #elif defined(HAVE_NEON)
-            gaps = new NEONIdentity(parent, mold->identity);
+            identity = new NEONIdentity(parent, mold->identity);
 #else
             identity = new Identity(parent, mold->identity);
 #endif
@@ -342,7 +342,7 @@ namespace statistics {
 #elif defined(HAVE_SSE2)
         overlap = new SSE2Overlap(parent, mold->overlap);
 #elif defined(HAVE_NEON)
-        overlap = new NEOnOverlap(parent, mold->overlap);
+        overlap = new NEONOverlap(parent, mold->overlap);
 #else
         overlap = new Overlap(parent, mold->overlap);
 #endif

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -229,7 +229,15 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (identity == nullptr) {
+#if defined(HAVE_AVX2)
+            identity = new AVX2Identity(alig);
+#elif defined(HAVE_SSE2)
+            identity = new SSE2Identity(alig);
+#elif defined(HAVE_NEON)
+            identity = new NEONIdentity(alig);
+#else
             identity = new Identity(alig);
+#endif
             identity->calculateSeqIdentity();
         }
         return true;

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -34,11 +34,14 @@
 #include "Statistics/Overlap.h"
 #include "InternalBenchmarker.h"
 
-#if defined(HAVE_SSE2)
-#include "Platform/x86/SSE2.h"
-#endif
 #if defined(HAVE_AVX2)
 #include "Platform/x86/AVX2.h"
+#endif
+#if defined(HAVE_NEON)
+#include "Platform/Arm/NEON.h"
+#endif
+#if defined(HAVE_SSE2)
+#include "Platform/x86/SSE2.h"
 #endif
 
 namespace statistics {
@@ -119,6 +122,8 @@ namespace statistics {
             alig->Statistics->similarity = new AVX2Similarity(alig);
 #elif defined(HAVE_SSE2)
             alig->Statistics->similarity = new SSE2Similarity(alig);
+#elif defined(HAVE_NEON)
+            alig->Statistics->similarity = new NEONSimilarity(alig);
 #else
             alig->Statistics->similarity = new Similarity(alig);
 #endif
@@ -194,6 +199,8 @@ namespace statistics {
             gaps = new AVX2Gaps(alig);
 #elif defined(HAVE_SSE2)
             gaps = new SSE2Gaps(alig);
+#elif defined(HAVE_NEON)
+            gaps = new NEONGaps(alig);
 #else
             gaps = new Gaps(alig);
 #endif
@@ -236,6 +243,8 @@ namespace statistics {
             overlap = new AVX2Overlap(alig);
 #elif defined(HAVE_SSE2)
             overlap = new SSE2Overlap(alig);
+#elif defined(HAVE_NEON)
+            overlap = new NEONOverlap(alig);
 #else
             overlap = new Overlap(alig);
 #endif
@@ -260,6 +269,8 @@ namespace statistics {
             overlap = new AVX2Overlap(alig);
 #elif defined(HAVE_SSE2)
             overlap = new SSE2Overlap(alig);
+#elif defined(HAVE_NEON)
+            overlap = new NEONOverlap(alig);
 #else
             overlap = new Overlap(alig);
 #endif
@@ -294,6 +305,8 @@ namespace statistics {
             similarity = new AVX2Similarity(parent, mold->similarity);
 #elif defined(HAVE_SSE2)
             similarity = new SSE2Similarity(parent, mold->similarity);
+#elif defined(HAVE_NEON)
+            similarity = new NEONSimilarity(parent, mold->similarity);
 #else
             similarity = new Similarity(parent, mold->similarity);
 #endif
@@ -306,6 +319,8 @@ namespace statistics {
             gaps = new AVX2Gaps(parent, mold->gaps);
 #elif defined(HAVE_SSE2)
             gaps = new SSE2Gaps(parent, mold->gaps);
+#elif defined(HAVE_NEON)
+            gaps = new NEONGaps(parent, mold->gaps);
 #else
             gaps = new Gaps(parent, mold->gaps);
 #endif
@@ -315,6 +330,8 @@ namespace statistics {
             identity = new AVX2Identity(parent, mold->identity);
 #elif defined(HAVE_SSE2)
             identity = new SSE2Identity(parent, mold->identity);
+#elif defined(HAVE_NEON)
+            gaps = new NEONIdentity(parent, mold->identity);
 #else
             identity = new Identity(parent, mold->identity);
 #endif
@@ -324,6 +341,8 @@ namespace statistics {
         overlap = new AVX2Overlap(parent, mold->overlap);
 #elif defined(HAVE_SSE2)
         overlap = new SSE2Overlap(parent, mold->overlap);
+#elif defined(HAVE_NEON)
+        overlap = new NEOnOverlap(parent, mold->overlap);
 #else
         overlap = new Overlap(parent, mold->overlap);
 #endif

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -59,7 +59,15 @@ namespace statistics {
         // It the similarity statistics object has not been
         // created we create it
         if (similarity == nullptr) {
+#if defined(HAVE_AVX2)
+            similarity = new AVX2Similarity(alig);
+#elif defined(HAVE_SSE2)
+            similarity = new SSE2Similarity(alig);
+#elif defined(HAVE_NEON)
+            similarity = new NEONSimilarity(alig);
+#else
             similarity = new Similarity(alig);
+#endif
             similarity->setSimilarityMatrix(_similarityMatrix);
             similarity->applyWindow(shWindow);
         }

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -34,6 +34,10 @@
 #include "Statistics/Overlap.h"
 #include "InternalBenchmarker.h"
 
+#if defined(HAVE_SSE2)
+#include "Platform/x86/SSE2.h"
+#endif
+
 namespace statistics {
     bool Manager::calculateConservationStats() {
         // Create a timerLevel that will report times upon its destruction
@@ -108,7 +112,11 @@ namespace statistics {
 
         // If scons object is not created, we create them
         if (alig->Statistics->similarity == nullptr)
+#if defined(HAVE_SSE2)
+            alig->Statistics->similarity = new SSE2Similarity(alig);
+#else
             alig->Statistics->similarity = new Similarity(alig);
+#endif
 
         // Associate the matrix to the similarity statistics object
         // If it's OK, we return true
@@ -177,7 +185,11 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (gaps == nullptr) {
+#if defined(HAVE_SSE2)
+            gaps = new SSE2Gaps(alig);
+#else
             gaps = new Gaps(alig);
+#endif
             gaps->CalculateVectors();
         }
         return gaps->applyWindow(ghWindow);
@@ -213,7 +225,11 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
+#if defined(HAVE_SSE2)
+            overlap = new SSE2Overlap(alig);
+#else
             overlap = new Overlap(alig);
+#endif
             overlap->calculateSeqOverlap();
         }
         return true;
@@ -231,7 +247,11 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
+#if defined(HAVE_SSE2)
+            overlap = new SSE2Overlap(alig);
+#else
             overlap = new Overlap(alig);
+#endif
         }
 
         return overlap->calculateSpuriousVector(overlapColumn, spuriousVector);
@@ -259,19 +279,36 @@ namespace statistics {
         shWindow = mold->shWindow;
 
         if (mold->similarity)
+#if defined(HAVE_SSE2)
+            similarity = new SSE2Similarity(parent, mold->similarity);
+#else
             similarity = new Similarity(parent, mold->similarity);
+#endif
 
         if (mold->consistency)
             consistency = new Consistency(parent, mold->consistency);
 
         if (mold->gaps)
+#if defined(HAVE_SSE2)
+            gaps = new SSE2Gaps(parent, mold->gaps);
+#else
             gaps = new Gaps(parent, mold->gaps);
+#endif
 
         if (mold->identity)
+#if defined(HAVE_SSE2)
+            identity = new SSE2Identity(parent, mold->identity);
+#else
             identity = new Identity(parent, mold->identity);
+#endif
 
         if (mold->overlap)
-            overlap = new Overlap(parent, mold->overlap);
+#if defined(HAVE_SSE2)
+        overlap = new SSE2Overlap(parent, mold->overlap);
+#else
+        overlap = new Overlap(parent, mold->overlap);
+#endif
+
     }
 
     Manager::~Manager() {

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -37,6 +37,9 @@
 #if defined(HAVE_SSE2)
 #include "Platform/x86/SSE2.h"
 #endif
+#if defined(HAVE_AVX2)
+#include "Platform/x86/AVX2.h"
+#endif
 
 namespace statistics {
     bool Manager::calculateConservationStats() {
@@ -112,7 +115,9 @@ namespace statistics {
 
         // If scons object is not created, we create them
         if (alig->Statistics->similarity == nullptr)
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            alig->Statistics->similarity = new AVX2Similarity(alig);
+#elif defined(HAVE_SSE2)
             alig->Statistics->similarity = new SSE2Similarity(alig);
 #else
             alig->Statistics->similarity = new Similarity(alig);
@@ -185,7 +190,9 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (gaps == nullptr) {
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            gaps = new AVX2Gaps(alig);
+#elif defined(HAVE_SSE2)
             gaps = new SSE2Gaps(alig);
 #else
             gaps = new Gaps(alig);
@@ -225,7 +232,9 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            overlap = new AVX2Overlap(alig);
+#elif defined(HAVE_SSE2)
             overlap = new SSE2Overlap(alig);
 #else
             overlap = new Overlap(alig);
@@ -247,7 +256,9 @@ namespace statistics {
         // If sgaps object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            overlap = new AVX2Overlap(alig);
+#elif defined(HAVE_SSE2)
             overlap = new SSE2Overlap(alig);
 #else
             overlap = new Overlap(alig);
@@ -279,7 +290,9 @@ namespace statistics {
         shWindow = mold->shWindow;
 
         if (mold->similarity)
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            similarity = new AVX2Similarity(parent, mold->similarity);
+#elif defined(HAVE_SSE2)
             similarity = new SSE2Similarity(parent, mold->similarity);
 #else
             similarity = new Similarity(parent, mold->similarity);
@@ -289,21 +302,27 @@ namespace statistics {
             consistency = new Consistency(parent, mold->consistency);
 
         if (mold->gaps)
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            gaps = new AVX2Gaps(parent, mold->gaps);
+#elif defined(HAVE_SSE2)
             gaps = new SSE2Gaps(parent, mold->gaps);
 #else
             gaps = new Gaps(parent, mold->gaps);
 #endif
 
         if (mold->identity)
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+            identity = new AVX2Identity(parent, mold->identity);
+#elif defined(HAVE_SSE2)
             identity = new SSE2Identity(parent, mold->identity);
 #else
             identity = new Identity(parent, mold->identity);
 #endif
 
         if (mold->overlap)
-#if defined(HAVE_SSE2)
+#if defined(HAVE_AVX2)
+        overlap = new AVX2Overlap(parent, mold->overlap);
+#elif defined(HAVE_SSE2)
         overlap = new SSE2Overlap(parent, mold->overlap);
 #else
         overlap = new Overlap(parent, mold->overlap);


### PR DESCRIPTION
## Overview

This PR adds SIMD implementations of the `Identity`, `Gaps`, `Overlaps` and `Similarity` statistics. The way it's organized:

- the `template.h` file contains C++ templates with the implementation of the different functions over an abstract `Vector` type
- the `AVX2.h`, `SSE2.h` and `NEON.h` files contain the concrete implementations for AVX2 (256 bits), SSE2 (128 bits) and NEON (128 bits) vectors
- The choice for a SIMD implementation is done at compile-time in the `Manager` class, which acts as a dispatcher.
 
 I'll add the dynamic dispatch afterwards because it's gonna be a large PR as well, as it needs to pull in and build https://github.com/google/cpu_features to work properly.

## Build

The CMake build will autodetect the best CPU features available. They can be individually disabled to build a version of the binary without SIMD (for testing):

- `cmake . -DDISABLE_SSE2=1 -DDISABLE_AVX2=1` will build without SIMD
- `cmake . -DDISABLE_SSE2=0 -DDISABLE_AVX2=1` will build with SSE2 only
- `cmake . -DDISABLE_SSE2=0 -DDISABLE_AVX2=0` (or just `cmake .`) will build with AVX2 and SSE2 (and effectively use AVX2).

## Tests

To test, I built the SSE2 and the generic binary and compared the outputs for all amino-acid examples with the `-strict`, `-strictplus`, `-gappyout`, `-clusters 5`, `-automated1` and `-resoverlap 0.8 -seqoverlap 75`. Output matched perfectly, but perhaps you'd want to have stricter test cases to compare the expected outputs.

## Benchmarks

I compared the runtime for the AVX2, SSE2 and current implementation on `example.039.AA.bctoNOG.ENOG41099YD.fasta`. The AVX2 code offers a x6 to x12 speedup, with more impressive returns for the overlap statistics. I think it should be feasible to add a SIMD version `Similarity::calculateVectors` for AVX2 using *gather* instructions, but I'm not sure it can be generalized to the other instruction sets.

#### `-strictplus`

<details>
<pre>
Benchmark 1: ./trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -strictplus
  Time (mean ± σ):      1.698 s ±  0.104 s    [User: 1.672 s, System: 0.012 s]
  Range (min … max):    1.494 s …  1.842 s    10 runs
Benchmark 2: ./trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -strictplus
  Time (mean ± σ):     341.3 ms ±  29.0 ms    [User: 332.6 ms, System: 6.2 ms]
  Range (min … max):   306.0 ms … 407.1 ms    10 runs
Benchmark 3: ./trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -strictplus
  Time (mean ± σ):     277.0 ms ±  29.1 ms    [User: 268.3 ms, System: 6.0 ms]
  Range (min … max):   244.5 ms … 328.0 ms    11 runs
Summary
  './trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -strictplus' ran
    1.23 ± 0.17 times faster than './trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -strictplus'
    6.13 ± 0.75 times faster than './trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -strictplus'
</pre>
</details>

#### `-automated1`

<details>
<pre>
Benchmark 1: ./trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -automated1
  Time (mean ± σ):      4.159 s ±  1.177 s    [User: 3.953 s, System: 0.024 s]
  Range (min … max):    3.289 s …  6.908 s    10 runs
Benchmark 2: ./trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -automated1
  Time (mean ± σ):     565.1 ms ±  43.7 ms    [User: 553.9 ms, System: 7.6 ms]
  Range (min … max):   523.5 ms … 672.8 ms    10 runs
Benchmark 3: ./trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -automated1
  Time (mean ± σ):     382.0 ms ±  34.2 ms    [User: 370.9 ms, System: 7.2 ms]
  Range (min … max):   329.2 ms … 424.5 ms    10 runs
Summary
  './trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -automated1' ran
    1.48 ± 0.17 times faster than './trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -automated1'
   10.89 ± 3.23 times faster than './trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -automated1'
</pre>
</details>

#### `-clusters 5`

<details>
<pre>
Benchmark 1: ./trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -clusters 5
  Time (mean ± σ):      1.906 s ±  0.139 s    [User: 1.893 s, System: 0.005 s]
  Range (min … max):    1.662 s …  2.148 s    10 runs
Benchmark 2: ./trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -clusters 5
  Time (mean ± σ):     321.7 ms ±  23.8 ms    [User: 314.8 ms, System: 5.5 ms]
  Range (min … max):   296.2 ms … 364.6 ms    10 runs
Benchmark 3: ./trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -clusters 5
  Time (mean ± σ):     253.5 ms ±  21.0 ms    [User: 245.1 ms, System: 6.3 ms]
  Range (min … max):   220.0 ms … 294.6 ms    10 runs
Summary
  './trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -clusters 5' ran
    1.27 ± 0.14 times faster than './trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -clusters 5'
    7.52 ± 0.83 times faster than './trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -clusters 5'
</pre>
</details>


#### `-resoverlap 0.8 -seqoverlap 75`

<details>
<pre>
Benchmark 1: ./trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -resoverlap 0.8 -seqoverlap 75
  Time (mean ± σ):      3.404 s ±  0.200 s    [User: 3.370 s, System: 0.013 s]
  Range (min … max):    3.124 s …  3.766 s    10 runs
Benchmark 2: ./trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -resoverlap 0.8 -seqoverlap 75
  Time (mean ± σ):     414.4 ms ±  83.4 ms    [User: 396.1 ms, System: 14.7 ms]
  Range (min … max):   354.4 ms … 585.1 ms    10 runs
Benchmark 3: ./trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -resoverlap 0.8 -seqoverlap 75
  Time (mean ± σ):     299.4 ms ±  49.1 ms    [User: 289.2 ms, System: 8.1 ms]
  Range (min … max):   251.2 ms … 394.5 ms    11 runs
Summary
  './trimal_avx2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -resoverlap 0.8 -seqoverlap 75' ran
    1.38 ± 0.36 times faster than './trimal_sse2 -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /tmp/test -resoverlap 0.8 -seqoverlap 75'
   11.37 ± 1.98 times faster than './trimal_generic -in ../dataset/example.039.AA.bctoNOG.ENOG41099YD.fasta -out /dev/null -resoverlap 0.8 -seqoverlap 75'
</pre>
</details>
