### PR TITLE
Implement runtime dispatch of SIMD code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
         
     steps:
       - uses: actions/checkout@v3
+        with:
+            submodules: true
       - name: Build trimal for Linux x86_64
         if: matrix.arch == 'x86_64' && matrix.cpu_instr == 'non_SIMD' 
         run: cmake . -DDISABLE_SSE2=1 -DDISABLE_AVX2=1 && make && file bin/trimal && file bin/readal &&

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/cpu_features"]
+	path = vendor/cpu_features
+	url = https://github.com/google/cpu_features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ add_executable(test
         ${TRIMAL_OBJECTS})
 SET_TARGET_PROPERTIES(test PROPERTIES EXCLUDE_FROM_ALL True)
 
+# Add `cpu_features` for detecting supported SIMD at compile time
+add_subdirectory(vendor/cpu_features)
+include_directories(vendor/cpu_features/include)
+target_link_libraries(trimal cpu_features)
+target_link_libraries(readal cpu_features)
+
 # Link the mathematical library to the targets
 target_link_libraries(trimal m)
 target_link_libraries(readal m)

--- a/include/Statistics/Manager.h
+++ b/include/Statistics/Manager.h
@@ -46,12 +46,26 @@ namespace statistics {
     class Overlap;
 
     /**
+     * \brief Enum to store the different supported compute kernels for the statistics.
+     */
+    enum ComputePlatform {
+        NONE,
+        SSE2,
+        AVX2,
+        NEON,
+    };
+
+    /**
      * \brief Class to handle the interaction with Alignment and statistics objects.\n
      * It serves as a wrapper or intermediate between the alignment and each specific stat.\n
      * It also encapsulates the similarityMatrix.
      */
     class Manager {
     public:
+        /**
+         * \brief
+         * */
+        ComputePlatform platform = ComputePlatform::NONE;
 
         /**
          * \brief Gaps submodule

--- a/include/reportsystem.h
+++ b/include/reportsystem.h
@@ -305,6 +305,8 @@ enum InfoCode {
 
     RemovingDuplicateSequences                  = 4,
 
+    UsingPlatform                               = 5,
+
 
     __MAXINFO
 };

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -423,7 +423,9 @@ namespace statistics {
         // On Aarch64, test whether NEON is supported.
 #ifdef CPU_FEATURES_ARCH_ARM
 #ifdef HAVE_NEON
-        platform = ComputePlatform::NEON;
+        if (features.neon != 0) {
+            platform = ComputePlatform::NEON;
+        }
 #endif
 #endif
 

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -313,38 +313,38 @@ namespace statistics {
         static const X86Info info = GetX86Info();
         static const X86Features features = info.features;
 
-#if defined(CPU_FEATURES_ARCH_X86_32)
-#if defined(HAVE_SSE2)
+#ifdef CPU_FEATURES_ARCH_X86_32
+#ifdef HAVE_SSE2
         if (features.sse2 != 0) {
             platform = ComputePlatform::SSE2;
         }
 #endif
-#if defined(HAVE_AVX2)
+#ifdef HAVE_AVX2
         if (features.avx2 != 0) {
             platform = ComputePlatform::AVX2;
         }
 #endif
 #endif
 
-#if defined(CPU_FEATURES_ARCH_X86_64)
-#if defined(HAVE_SSE2)
+#ifdef CPU_FEATURES_ARCH_X86_64
+#ifdef HAVE_SSE2
         platform = ComputePlatform::SSE2;
 #endif
-#if defined(HAVE_AVX2)
+#ifdef HAVE_AVX2
         if (features.avx2 != 0) {
             platform = ComputePlatform::AVX2;
         }
 #endif
 #endif
 
-#if defined(CPU_FEATURES_ARCH_AARCH64)
-#if defined(HAVE_NEON)
+#ifdef CPU_FEATURES_ARCH_AARCH64
+#ifdef HAVE_NEON
         platform = ComputePlatform::NEON;
 #endif
 #endif
 
-#if defined(CPU_FEATURES_ARCH_ARM)
-#if defined(HAVE_NEON)
+#ifdef CPU_FEATURES_ARCH_ARM
+#ifdef HAVE_NEON
         platform = ComputePlatform::NEON;
 #endif
 #endif
@@ -361,55 +361,98 @@ namespace statistics {
         ghWindow = mold->ghWindow;
         shWindow = mold->shWindow;
 
-        kernel = mold->kernel;
+        platform = mold->platform;
 
-        if (mold->similarity)
-#if defined(HAVE_AVX2)
-            similarity = new AVX2Similarity(parent, mold->similarity);
-#elif defined(HAVE_SSE2)
-            similarity = new SSE2Similarity(parent, mold->similarity);
-#elif defined(HAVE_NEON)
-            similarity = new NEONSimilarity(parent, mold->similarity);
-#else
-            similarity = new Similarity(parent, mold->similarity);
+        if (mold->similarity) {
+
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case(ComputePlatform::AVX2):
+                similarity = new AVX2Similarity(parent, mold->similarity);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case(ComputePlatform::SSE2):
+                similarity = new SSE2Similarity(parent, mold->similarity);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case(ComputePlatform::NEON):
+                similarity = new NEONSimilarity(parent, mold->similarity);
+                break;
+#endif
+            default:
+                similarity = new Similarity(parent, mold->similarity);
+            }
+        }
 
         if (mold->consistency)
             consistency = new Consistency(parent, mold->consistency);
 
-        if (mold->gaps)
-#if defined(HAVE_AVX2)
-            gaps = new AVX2Gaps(parent, mold->gaps);
-#elif defined(HAVE_SSE2)
-            gaps = new SSE2Gaps(parent, mold->gaps);
-#elif defined(HAVE_NEON)
-            gaps = new NEONGaps(parent, mold->gaps);
-#else
-            gaps = new Gaps(parent, mold->gaps);
+        if (mold->gaps) {
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case(ComputePlatform::AVX2):
+                gaps = new AVX2Gaps(parent, mold->gaps);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case(ComputePlatform::SSE2):
+                gaps = new SSE2Gaps(parent, mold->gaps);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case(ComputePlatform::NEON):
+                gaps = new NEONGaps(parent, mold->gaps);
+                break;
+#endif
+            default:
+                gaps = new Gaps(parent, mold->gaps);
+            }
+        }
 
-        if (mold->identity)
-#if defined(HAVE_AVX2)
-            identity = new AVX2Identity(parent, mold->identity);
-#elif defined(HAVE_SSE2)
-            identity = new SSE2Identity(parent, mold->identity);
-#elif defined(HAVE_NEON)
-            identity = new NEONIdentity(parent, mold->identity);
-#else
-            identity = new Identity(parent, mold->identity);
+        if (mold->identity) {
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case(ComputePlatform::AVX2):
+                identity = new AVX2Identity(parent, mold->identity);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case(ComputePlatform::SSE2):
+                identity = new SSE2Identity(parent, mold->identity);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case(ComputePlatform::NEON):
+                identity = new NEONIdentity(parent, mold->identity);
+                break;
+#endif
+            default:
+                identity = new Identity(parent, mold->identity);                
+            }
+        }
 
         if (mold->overlap)
-#if defined(HAVE_AVX2)
-        overlap = new AVX2Overlap(parent, mold->overlap);
-#elif defined(HAVE_SSE2)
-        overlap = new SSE2Overlap(parent, mold->overlap);
-#elif defined(HAVE_NEON)
-        overlap = new NEONOverlap(parent, mold->overlap);
-#else
-        overlap = new Overlap(parent, mold->overlap);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case(ComputePlatform::AVX2):
+                overlap = new AVX2Overlap(parent, mold->overlap);
+                break;
 #endif
-
+#ifdef HAVE_SSE2
+            case(ComputePlatform::SSE2):
+                overlap = new SSE2Overlap(parent, mold->overlap);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case(ComputePlatform::NEON):
+                overlap = new NEONOverlap(parent, mold->overlap);
+                break;
+#endif
+            default:
+                overlap = new Overlap(parent, mold->overlap);                
+            }
     }
 
     Manager::~Manager() {

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -65,15 +65,26 @@ namespace statistics {
         // It the similarity statistics object has not been
         // created we create it
         if (similarity == nullptr) {
-#if defined(HAVE_AVX2)
-            similarity = new AVX2Similarity(alig);
-#elif defined(HAVE_SSE2)
-            similarity = new SSE2Similarity(alig);
-#elif defined(HAVE_NEON)
-            similarity = new NEONSimilarity(alig);
-#else
-            similarity = new Similarity(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                similarity = new AVX2Similarity(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                similarity = new SSE2Similarity(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                similarity = new NEONSimilarity(alig);
+                break;
+#endif
+            default:
+                similarity = new Similarity(alig);
+            }
+
             similarity->setSimilarityMatrix(_similarityMatrix);
             similarity->applyWindow(shWindow);
         }
@@ -132,15 +143,25 @@ namespace statistics {
 
         // If scons object is not created, we create them
         if (alig->Statistics->similarity == nullptr)
-#if defined(HAVE_AVX2)
-            alig->Statistics->similarity = new AVX2Similarity(alig);
-#elif defined(HAVE_SSE2)
-            alig->Statistics->similarity = new SSE2Similarity(alig);
-#elif defined(HAVE_NEON)
-            alig->Statistics->similarity = new NEONSimilarity(alig);
-#else
-            alig->Statistics->similarity = new Similarity(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                alig->Statistics->similarity = new AVX2Similarity(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                alig->Statistics->similarity = new SSE2Similarity(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                alig->Statistics->similarity = new NEONSimilarity(alig);
+                break;
+#endif
+            default:
+                alig->Statistics->similarity = new Similarity(alig);
+            }
 
         // Associate the matrix to the similarity statistics object
         // If it's OK, we return true
@@ -209,15 +230,25 @@ namespace statistics {
         // If gaps object is not created, we create them
         // and calculate the statistics
         if (gaps == nullptr) {
-#if defined(HAVE_AVX2)
-            gaps = new AVX2Gaps(alig);
-#elif defined(HAVE_SSE2)
-            gaps = new SSE2Gaps(alig);
-#elif defined(HAVE_NEON)
-            gaps = new NEONGaps(alig);
-#else
-            gaps = new Gaps(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                gaps = new AVX2Gaps(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                gaps = new SSE2Gaps(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                gaps = new NEONGaps(alig);
+                break;
+#endif
+            default:
+                gaps = new Gaps(alig);
+            }
             gaps->CalculateVectors();
         }
         return gaps->applyWindow(ghWindow);
@@ -235,15 +266,25 @@ namespace statistics {
         // If identity object is not created, we create them
         // and calculate the statistics
         if (identity == nullptr) {
-#if defined(HAVE_AVX2)
-            identity = new AVX2Identity(alig);
-#elif defined(HAVE_SSE2)
-            identity = new SSE2Identity(alig);
-#elif defined(HAVE_NEON)
-            identity = new NEONIdentity(alig);
-#else
-            identity = new Identity(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                identity = new AVX2Identity(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                identity = new SSE2Identity(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                identity = new NEONIdentity(alig);
+                break;
+#endif
+            default:
+                identity = new Identity(alig);
+            }
             identity->calculateSeqIdentity();
         }
         return true;
@@ -261,15 +302,25 @@ namespace statistics {
         // If overlap object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
-#if defined(HAVE_AVX2)
-            overlap = new AVX2Overlap(alig);
-#elif defined(HAVE_SSE2)
-            overlap = new SSE2Overlap(alig);
-#elif defined(HAVE_NEON)
-            overlap = new NEONOverlap(alig);
-#else
-            overlap = new Overlap(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                overlap = new AVX2Overlap(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                overlap = new SSE2Overlap(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                overlap = new NEONOverlap(alig);
+                break;
+#endif
+            default:
+                overlap = new Overlap(alig);
+            }
             overlap->calculateSeqOverlap();
         }
         return true;
@@ -287,15 +338,25 @@ namespace statistics {
         // If overlap object is not created, we create them
         // and calculate the statistics
         if (overlap == nullptr) {
-#if defined(HAVE_AVX2)
-            overlap = new AVX2Overlap(alig);
-#elif defined(HAVE_SSE2)
-            overlap = new SSE2Overlap(alig);
-#elif defined(HAVE_NEON)
-            overlap = new NEONOverlap(alig);
-#else
-            overlap = new Overlap(alig);
+            switch (platform) {
+#ifdef HAVE_AVX2
+            case ComputePlatform::AVX2:
+                overlap = new AVX2Overlap(alig);
+                break;
 #endif
+#ifdef HAVE_SSE2
+            case ComputePlatform::SSE2:
+                overlap = new SSE2Overlap(alig);
+                break;
+#endif
+#ifdef HAVE_NEON
+            case ComputePlatform::NEON:
+                overlap = new NEONOverlap(alig);
+                break;
+#endif
+            default:
+                overlap = new Overlap(alig);
+            }
         }
 
         return overlap->calculateSpuriousVector(overlapColumn, spuriousVector);
@@ -310,9 +371,11 @@ namespace statistics {
         ghWindow = 0;
         shWindow = 0;
 
+        // Detect the best supported compute platform on the local machine.
         static const X86Info info = GetX86Info();
         static const X86Features features = info.features;
 
+        // On x86, test whether SSE2 or AVX2 are supported.
 #ifdef CPU_FEATURES_ARCH_X86_32
 #ifdef HAVE_SSE2
         if (features.sse2 != 0) {
@@ -326,6 +389,7 @@ namespace statistics {
 #endif
 #endif
 
+        // On x86-64, SSE2 is always supported, test whether AVX2 is supported.
 #ifdef CPU_FEATURES_ARCH_X86_64
 #ifdef HAVE_SSE2
         platform = ComputePlatform::SSE2;
@@ -337,12 +401,14 @@ namespace statistics {
 #endif
 #endif
 
+        // On Aarch64, NEON is always supported.
 #ifdef CPU_FEATURES_ARCH_AARCH64
 #ifdef HAVE_NEON
         platform = ComputePlatform::NEON;
 #endif
 #endif
 
+        // On Aarch64, test whether NEON is supported.
 #ifdef CPU_FEATURES_ARCH_ARM
 #ifdef HAVE_NEON
         platform = ComputePlatform::NEON;

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -29,7 +29,13 @@
 
 #include <iostream>
 
+#if defined(__x86_64__) || defined(__i386__)
 #include "cpuinfo_x86.h"
+#elif defined(__arm__)
+#include "cpuinfo_arm.h"
+#elif defined(__aarch64__)
+#include "cpuinfo_aarch64.h"
+#endif
 
 #include "Statistics/Similarity.h"
 #include "Statistics/Consistency.h"
@@ -373,8 +379,13 @@ namespace statistics {
         shWindow = 0;
 
         // Detect the best supported compute platform on the local machine.
+#if defined(CPU_FEATURES_ARCH_X86)
         static const X86Info info = GetX86Info();
         static const X86Features features = info.features;
+#elif defined(CPU_FEATURES_ARCH_ARM)
+        static const ArmInfo info = GetArmInfo();
+        static const ArmFeatures features = info.features;
+#endif
 
         // On x86, test whether SSE2 or AVX2 are supported.
 #ifdef CPU_FEATURES_ARCH_X86_32

--- a/source/Statistics/Manager.cpp
+++ b/source/Statistics/Manager.cpp
@@ -36,6 +36,7 @@
 #include "Statistics/Identity.h"
 #include "Statistics/Manager.h"
 #include "Statistics/Overlap.h"
+#include "reportsystem.h"
 #include "InternalBenchmarker.h"
 
 #if defined(HAVE_AVX2)
@@ -414,6 +415,19 @@ namespace statistics {
         platform = ComputePlatform::NEON;
 #endif
 #endif
+
+        switch(platform) {
+            case ComputePlatform::AVX2:
+                debug.report(InfoCode::UsingPlatform, new std::string[1]{"AVX2"});
+                break;
+            case ComputePlatform::SSE2:
+                debug.report(InfoCode::UsingPlatform, new std::string[1]{"SSE2"});
+                break;
+            case ComputePlatform::NEON:
+                debug.report(InfoCode::UsingPlatform, new std::string[1]{"NEON"});
+                break;
+        }
+
     }
 
     Manager::Manager(Alignment *parent, Manager *mold) {

--- a/source/reportMessages/infoMessages.cpp
+++ b/source/reportMessages/infoMessages.cpp
@@ -44,5 +44,8 @@ const std::map<InfoCode, const char *> reporting::reportManager::InfoMessages =
     },
 
     {InfoCode::RemovingDuplicateSequences,
-                "Removing sequence \"[tag]\" as it is a duplicate of \"[tag]\"."}
+                "Removing sequence \"[tag]\" as it is a duplicate of \"[tag]\"."},
+
+    {InfoCode::UsingPlatform,
+                "Using \"[tag]\" CPU extensions to compute statistics."}
 };


### PR DESCRIPTION
Hi @nicodr97 !

Sorry for the small delay in getting this implemented, I finally got to sit down and work on some extra code besides what I need for my PhD :smile: 

I added the `cpu_features` from Google as a `git` submodule, and updated the CMake files to compile it as a subdirectory. `cpu_features` is available under the Apache 2.0 license so there is no licensing issue here. When a new `Manager` is creeate, it checks the local CPU feature flags to check what backend is supported, using a mixture of compilation flags and runtime flags:

- on `x86`, it checks for SSE2 and AVX2
- on `x86-64`, SSE2 is always available, it checks for AVX2
- on `arm`, it checks for NEON
- on `aarch64`, NEON is always supported. 

It's still possible to disable AVX2, NEON, or SSE2 at compile time; but now a single binary can be compiled and distributed for each platforms. I also added an `[INFO]`-level message to report when an optimized implementation of the statistics is being used, to make it easier to debug.