### PR TITLE
Refactor the parsers for better compatibility and memory usage

### DIFF
--- a/include/FormatHandling/BaseFormatHandler.h
+++ b/include/FormatHandling/BaseFormatHandler.h
@@ -32,6 +32,7 @@
 
 #include "Alignment/Alignment.h"
 #include "reportsystem.h"
+#include "utils.h"
 
 #include <iomanip>
 
@@ -91,12 +92,21 @@ public:
                 <b> nullptr</b> if there was any error.
      */
     virtual Alignment *LoadAlignment(const std::string &filename) {
-        Alignment* ali;
+        Alignment* alignment;
         std::ifstream file;
+
         file.open(filename, std::ifstream::in);
-        ali = LoadAlignment(file);
+        if(!utils::checkFile(file))
+            return nullptr;
+
+        alignment = LoadAlignment(file);
+        if (alignment != nullptr) {
+            alignment->filename.append(filename);
+            alignment->filename.append(";");
+        }
+
         file.close();
-        return ali;
+        return alignment;
     }
 
     /**
@@ -105,7 +115,7 @@ public:
      \return    <b> Alignment</b> loaded with the information of the file. \n
                 <b> nullptr</b> if there was any error.
      */
-    virtual Alignment *LoadAlignment(std::istream& stream) = 0;
+    virtual Alignment *LoadAlignment(std::istream &file) = 0;
 
     /**
      \brief Function to save a \link Alignment \endlink to a file.

--- a/include/FormatHandling/BaseFormatHandler.h
+++ b/include/FormatHandling/BaseFormatHandler.h
@@ -101,8 +101,14 @@ public:
 
         alignment = LoadAlignment(file);
         if (alignment != nullptr) {
-            alignment->filename.append(filename);
-            alignment->filename.append(";");
+            /* Alignment title may be set by the format handler, dependending on 
+             * the alignment format, so it should only be set here if there was
+             * none parsed already.
+             */
+            if (alignment->filename.empty()) {
+                alignment->filename.append(filename);
+                alignment->filename.append(";");
+            }
         }
 
         file.close();

--- a/include/FormatHandling/BaseFormatHandler.h
+++ b/include/FormatHandling/BaseFormatHandler.h
@@ -90,7 +90,22 @@ public:
      \return    <b> Alignment</b> loaded with the information of the file. \n
                 <b> nullptr</b> if there was any error.
      */
-    virtual Alignment *LoadAlignment(const std::string &filename) = 0;
+    virtual Alignment *LoadAlignment(const std::string &filename) {
+        Alignment* ali;
+        std::ifstream file;
+        file.open(filename, std::ifstream::in);
+        ali = LoadAlignment(file);
+        file.close();
+        return ali;
+    }
+
+    /**
+     \brief Function to load a file in the current format and return an alignment object.
+     \param filename Filename of the file to load.
+     \return    <b> Alignment</b> loaded with the information of the file. \n
+                <b> nullptr</b> if there was any error.
+     */
+    virtual Alignment *LoadAlignment(std::istream& stream) = 0;
 
     /**
      \brief Function to save a \link Alignment \endlink to a file.

--- a/include/FormatHandling/clustal_state.h
+++ b/include/FormatHandling/clustal_state.h
@@ -45,7 +45,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/fasta_m10_state.h
+++ b/include/FormatHandling/fasta_m10_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/fasta_state.h
+++ b/include/FormatHandling/fasta_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/htmlreport_state.h
+++ b/include/FormatHandling/htmlreport_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/mega_interleaved_state.h
+++ b/include/FormatHandling/mega_interleaved_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/mega_sequential_state.h
+++ b/include/FormatHandling/mega_sequential_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/nexus_m10_state.h
+++ b/include/FormatHandling/nexus_m10_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/nexus_state.h
+++ b/include/FormatHandling/nexus_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip32_m10_state.h
+++ b/include/FormatHandling/phylip32_m10_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip32_state.h
+++ b/include/FormatHandling/phylip32_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip40_m10_state.h
+++ b/include/FormatHandling/phylip40_m10_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip40_state.h
+++ b/include/FormatHandling/phylip40_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip_paml_m10_state.h
+++ b/include/FormatHandling/phylip_paml_m10_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/phylip_paml_state.h
+++ b/include/FormatHandling/phylip_paml_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/FormatHandling/pir_state.h
+++ b/include/FormatHandling/pir_state.h
@@ -46,7 +46,7 @@ public:
 
     int CheckAlignment(std::istream *origin) override;
 
-    Alignment *LoadAlignment(const std::string &filename) override;
+    Alignment *LoadAlignment(std::istream& stream) override;
 
     bool SaveAlignment(const Alignment &alignment, std::ostream *output) override;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -265,7 +265,7 @@ namespace utils {
       nullptr if there is nothing to read.\n
       Line that has been read.
     */
-     char *readLine(std::istream &file);
+     char *readLine(std::istream &file, std::string &buffer);
 
     /**
      \brief Remove all content surrounded by ("") or ([]).\n

--- a/include/utils.h
+++ b/include/utils.h
@@ -257,19 +257,6 @@ namespace utils {
     /**
      \brief Read a new line from current input stream.\n
      This function is better than standard one
-      since cares of operative system compatibility.\n
-     It is useful as well because removes tabs and blank spaces
-      at lines at beginning/ending.\n
-     \param file ifstream to read line from.
-     \return \n
-        Line that has been read or
-        nullptr if there is nothing to read.\n
-     */
-     char *readLine(std::ifstream &file);
-
-    /**
-     \brief Read a new line from current input stream.\n
-     This function is better than standard one
      since cares of operative system compatibility.\n
      It is useful as well because removes tabs
      and blank spaces at lines at beginning/ending.\n

--- a/source/FormatHandling/clustal_state.cpp
+++ b/source/FormatHandling/clustal_state.cpp
@@ -69,19 +69,11 @@ int clustal_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* clustal_state::LoadAlignment(const std::string &filename)
+Alignment* clustal_state::LoadAlignment(std::istream &file)
 {
     Alignment* alignment = new Alignment();
     int i, seqLength, pos, firstBlock;
     char *str, *line = nullptr;
-    std::ifstream file;
-    file.open(filename, std::ifstream::in);
-    
-    /* Store some details about input file to be used in posterior format
-     * conversions */
-    // alignment.filename.append("!Title ");
-    alignment->filename.append(filename);
-    alignment->filename.append(";");
 
     /* The first valid line corresponding to CLUSTAL label is ignored */
     do {
@@ -226,9 +218,6 @@ Alignment* clustal_state::LoadAlignment(const std::string &filename)
         /* Read current line and analyze it*/
         line = utils::readLine(file);
     }
-
-    /* Close the input file */
-    file.close();
 
     /* Deallocate dinamic memory */
     delete [] line;

--- a/source/FormatHandling/clustal_state.cpp
+++ b/source/FormatHandling/clustal_state.cpp
@@ -39,18 +39,16 @@ int clustal_state::CheckAlignment(std::istream* origin)
     origin->seekg(0);
     origin->clear();
     char *firstWord = nullptr, *line = nullptr;
-
+    std::string buffer;
     
     /* Read first valid line in a safer way */
     do {
-        delete[] line;
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
     if (origin->eof())
     {
-        delete [] line;
         return false;
     }
 
@@ -60,11 +58,8 @@ int clustal_state::CheckAlignment(std::istream* origin)
     /* Clustal Format */
     if((!strcmp(firstWord, "CLUSTAL")) || (!strcmp(firstWord, "clustal")))
     {
-        delete [] line;
         return 1;
     }
-
-    delete[] line;
     
     return 0;
 }
@@ -74,11 +69,11 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
     Alignment* alignment = new Alignment();
     int i, seqLength, pos, firstBlock;
     char *str, *line = nullptr;
+    std::string buffer;
 
     /* The first valid line corresponding to CLUSTAL label is ignored */
     do {
-        delete [] line;
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     } while ((line == nullptr) && (!file.eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -87,12 +82,8 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
 
     /* Ignore blank lines before first sequence block starts */
     while(!file.eof()) {
-
-        /* Deallocate previously used dynamic memory */
-        delete [] line;
-
         /* Read lines in safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
         if (line != nullptr)
             break;
@@ -122,14 +113,9 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
             break;
         alignment->numberOfSequences++;
 
-        /* Deallocate previously used dynamic memory */
-        delete [] line;
-
         /* Read lines in safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     }
-
-    delete [] line;
 
     /* Finish to preprocess the input file. */
     file.clear();
@@ -140,7 +126,7 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
     alignment->sequences = new std::string[alignment->numberOfSequences];
 
     /* Read the title line and store it */
-    line = utils::readLine(file);
+    line = utils::readLine(file, buffer);
     if (line == nullptr)
         return nullptr;
     alignment->alignmentInfo.append(line, strlen(line));
@@ -148,11 +134,8 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
     /* Ignore blank lines before first sequence block starts */
     while(!file.eof()) {
 
-        /* Deallocate previously used dynamic memory */
-        delete [] line;
-
         /* Read lines in safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
         if (line != nullptr)
             break;
@@ -173,7 +156,7 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
             if (i == 0)
                 firstBlock = false;
             /* Read current line and analyze it*/
-            line = utils::readLine(file);
+            line = utils::readLine(file, buffer);
             continue;
         }
 
@@ -188,11 +171,8 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
         if (pos == seqLength) {
             firstBlock = false;
 
-            /* Deallocate dinamic memory if it has been used before */
-            delete [] line;
-
             /* Read current line and analyze it*/
-            line = utils::readLine(file);
+            line = utils::readLine(file, buffer);
 
             continue;
         }
@@ -212,15 +192,9 @@ Alignment* clustal_state::LoadAlignment(std::istream &file)
             i = (i + 1) % alignment->numberOfSequences;
         }
 
-        /* Deallocate dinamic memory if it has been used before */
-        delete [] line;
-
         /* Read current line and analyze it*/
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     }
-
-    /* Deallocate dinamic memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alignment->fillMatrices(true);

--- a/source/FormatHandling/fasta_m10_state.cpp
+++ b/source/FormatHandling/fasta_m10_state.cpp
@@ -38,7 +38,7 @@ int fasta_m10_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* fasta_m10_state::LoadAlignment(const std::string &filename)
+Alignment* fasta_m10_state::LoadAlignment(std::istream &file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/fasta_state.cpp
+++ b/source/FormatHandling/fasta_state.cpp
@@ -44,23 +44,12 @@ int fasta_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* fasta_state::LoadAlignment(const std::string &filename)
+Alignment* fasta_state::LoadAlignment(std::istream &file)
 {
     /* FASTA file format parser */
     Alignment* alig = new Alignment();
     char *str, *line = nullptr;
-    std::ifstream file;
     int i;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Store input file name for posterior uses in other formats */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     /* Compute how many sequences are in the input alignment */
     alig->numberOfSequences = 0;
@@ -130,9 +119,6 @@ Alignment* fasta_state::LoadAlignment(const std::string &filename)
             str = strtok(nullptr, DELIMITERS);
         }
     }
-
-    /* Close the input file */
-    file.close();
 
     /* Deallocate previously used dinamic memory */
     if (line != nullptr)

--- a/source/FormatHandling/fasta_state.cpp
+++ b/source/FormatHandling/fasta_state.cpp
@@ -50,16 +50,14 @@ Alignment* fasta_state::LoadAlignment(std::istream &file)
     Alignment* alig = new Alignment();
     char *str, *line = nullptr;
     int i;
+    std::string buffer;
 
     /* Compute how many sequences are in the input alignment */
     alig->numberOfSequences = 0;
     while(!file.eof()) {
 
-        /* Deallocate previously used dinamic memory */
-        delete [] line;
-
         /* Read lines in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -84,11 +82,8 @@ Alignment* fasta_state::LoadAlignment(std::istream &file)
 
     for(i = -1; (i < alig->numberOfSequences) && (!file.eof()); ) {
 
-        /* Deallocate previously used dinamic memory */
-        delete [] line;
-
         /* Read lines in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -120,10 +115,6 @@ Alignment* fasta_state::LoadAlignment(std::istream &file)
         }
     }
 
-    /* Deallocate previously used dinamic memory */
-    if (line != nullptr)
-        delete [] line;
-        
     /* Check the matrix's content */
     alig->fillMatrices(false);
     alig->originalNumberOfSequences = alig-> numberOfSequences;

--- a/source/FormatHandling/htmlreport_state.cpp
+++ b/source/FormatHandling/htmlreport_state.cpp
@@ -39,7 +39,7 @@ int htmlreport_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* htmlreport_state::LoadAlignment(const std::string &filename)
+Alignment* htmlreport_state::LoadAlignment(std::istream &file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/mega_interleaved_state.cpp
+++ b/source/FormatHandling/mega_interleaved_state.cpp
@@ -86,27 +86,14 @@ int mega_interleaved_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* mega_interleaved_state::LoadAlignment(const std::string &filename)
+Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
 {
     Alignment * alig = new Alignment();
    /* MEGA interleaved file format parser */
 
     char *frag = nullptr, *str = nullptr, *line = nullptr;
     int i, firstBlock = true;
-    std::ifstream file;
     
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Filename is stored as a title for MEGA input alignment.
-     * If it is detected later a label "TITLE" in input file, this information
-     * will be replaced for that one */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
-
     /* Skip first valid line */
     do {
         line = utils::readLine(file);
@@ -143,18 +130,15 @@ Alignment* mega_interleaved_state::LoadAlignment(const std::string &filename)
 
         /* If TITLE label is found, replace previously stored information with
          * this info */
-        std::string newFilename {filename};
         if(!strcmp(str, "TITLE")) {
-            newFilename.clear();
+            alig->filename.clear();
             if(strncmp(line, "!", 1))
-                newFilename += "!";
-            newFilename += line;
+                alig->filename += "!";
+            alig->filename += line;
         }
             /* If FORMAT label is found, try to get some details from input file */
         else if(!strcmp(str, "FORMAT"))
              alig->alignmentInfo.append(line, strlen(line));
-
-        alig->filename = newFilename;
 
         /* Destroy previously allocated memory */
         delete [] frag;
@@ -255,9 +239,6 @@ Alignment* mega_interleaved_state::LoadAlignment(const std::string &filename)
         if (i == 0)
             firstBlock = false;
     }
-
-    /* Close input file */
-    file.close();
 
     /* Deallocate local memory */
     delete [] line;

--- a/source/FormatHandling/mega_interleaved_state.cpp
+++ b/source/FormatHandling/mega_interleaved_state.cpp
@@ -41,17 +41,16 @@ int mega_interleaved_state::CheckAlignment(std::istream* origin)
     
     char c, *firstWord = nullptr, *line = nullptr;
     int blocks = 0;
-    std::string nline;
+    std::string buffer;
     
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
     if (origin->eof())
     {
-        delete [] line;
         return 0;
     }
 
@@ -78,11 +77,10 @@ int mega_interleaved_state::CheckAlignment(std::istream* origin)
                 blocks++;
         } while((c != '\n') && (!origin->eof()));
 
-        delete [] line;
         /* MEGA Sequential (22) or Interleaved (21) */
         return (!blocks) ? 0 : 1;
     }
-    delete[] line;
+    // delete[] line;
     return 0;
 }
 
@@ -93,10 +91,11 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
 
     char *frag = nullptr, *str = nullptr, *line = nullptr;
     int i, firstBlock = true;
+    std::string buffer;
     
     /* Skip first valid line */
     do {
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     } while ((line == nullptr) && (!file.eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -106,11 +105,8 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
     /* Try to get input alignment information */
     while(!file.eof()) {
 
-        /* Destroy previously allocated memory */
-        delete [] line;
-
         /* Read a new line in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -151,11 +147,8 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
         if(!strncmp(line, "#", 1))
             alig->numberOfSequences++;
 
-        /* Deallocate dynamic memory */
-        delete [] line;
-
         /* Read lines in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
         /* If a blank line is detected means first block of sequences is over */
         /* Then, break counting sequences loop */
@@ -172,16 +165,13 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
     alig->sequences = new std::string[alig->numberOfSequences];
 
     /* Skip first line */
-    line = utils::readLine(file);
+    line = utils::readLine(file, buffer);
 
     /* Skip lines until first # flag is reached */
     while(!file.eof()) {
 
-        /* Deallocate previously used dynamic memory */
-        delete [] line;
-
         /* Read line in a safer way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
         /* Determine whether a # flag has been found in current std::string */
         if (line != nullptr)
@@ -197,14 +187,14 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
 
         if (line == nullptr) {
             /* Read line in a safer way */
-            line = utils::readLine(file);
+            line = utils::readLine(file, buffer);
             continue;
         }
 
         if (!strncmp(line, "!", 1)) {
             /* Deallocate memory and read a new line */
-            delete [] line;
-            line = utils::readLine(file);
+            // delete [] line;
+            line = utils::readLine(file, buffer);
             continue;
         }
 
@@ -230,18 +220,13 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
         /* Deallocate previously used dynamic memory */
         delete [] frag;
 
-        delete [] line;
-
         /* Read line in a safer way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
         i = (i + 1) % alig->numberOfSequences;
         if (i == 0)
             firstBlock = false;
     }
-
-    /* Deallocate local memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/mega_interleaved_state.cpp
+++ b/source/FormatHandling/mega_interleaved_state.cpp
@@ -80,7 +80,6 @@ int mega_interleaved_state::CheckAlignment(std::istream* origin)
         /* MEGA Sequential (22) or Interleaved (21) */
         return (!blocks) ? 0 : 1;
     }
-    // delete[] line;
     return 0;
 }
 
@@ -193,7 +192,6 @@ Alignment* mega_interleaved_state::LoadAlignment(std::istream& file)
 
         if (!strncmp(line, "!", 1)) {
             /* Deallocate memory and read a new line */
-            // delete [] line;
             line = utils::readLine(file, buffer);
             continue;
         }

--- a/source/FormatHandling/mega_sequential_state.cpp
+++ b/source/FormatHandling/mega_sequential_state.cpp
@@ -85,26 +85,13 @@ int mega_sequential_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* mega_sequential_state::LoadAlignment(const std::string &filename)
+Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
 {
     Alignment * alig = new Alignment();
    /* MEGA sequential file format parser */
 
     char *frag = nullptr, *str = nullptr, *line = nullptr;
-    std::ifstream file;
     int i;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Filename is stored as a title for MEGA input alignment.
-     * If it is detected later a label "TITLE" in input file, this information
-     * will be replaced for that one */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     /* Skip first valid line */
     do {
@@ -268,9 +255,6 @@ Alignment* mega_sequential_state::LoadAlignment(const std::string &filename)
         /* Read a new line in a safe way */
         line = utils::readLine(file);
     }
-
-    /* Close input file */
-    file.close();
 
     /* Deallocate dynamic memory */
     delete [] line;

--- a/source/FormatHandling/mega_sequential_state.cpp
+++ b/source/FormatHandling/mega_sequential_state.cpp
@@ -41,17 +41,16 @@ int mega_sequential_state::CheckAlignment(std::istream* origin)
  
     char c, *firstWord = nullptr, *line = nullptr;
     int blocks = 0;
-    std::string nline;
+    std::string buffer;
 
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
     if (origin->eof())
     {
-        delete [] line;
         return 0;
     }
 
@@ -77,11 +76,9 @@ int mega_sequential_state::CheckAlignment(std::istream* origin)
                 blocks++;
         } while((c != '\n') && (!origin->eof()));
 
-        delete [] line;
         /* MEGA Sequential (22) or Interleaved (21) */
         return (!blocks) ? 1 : 0;
     }
-    delete[] line;
     return 0;
 }
 
@@ -92,10 +89,11 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
 
     char *frag = nullptr, *str = nullptr, *line = nullptr;
     int i;
+    std::string buffer;
 
     /* Skip first valid line */
     do {
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     } while ((line == nullptr) && (!file.eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -105,12 +103,8 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
     /* Try to get input alignment information */
     while(!file.eof()) {
 
-        /* Destroy previously allocated memory */
-        if (line != nullptr)
-            delete [] line;
-
         /* Read a new line in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -154,7 +148,7 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
 
         /* Check whether input line is valid or not */
         if (line == nullptr) {
-            line = utils::readLine(file);
+            line = utils::readLine(file, buffer);
             continue;
         }
 
@@ -162,11 +156,8 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
         if (!strncmp(line, "#", 1))
             alig->numberOfSequences++;
 
-        /* Destroy previously allocated memory */
-        delete [] line;
-
         /* Read a new line in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
 
     } while(!file.eof());
 
@@ -179,16 +170,13 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
     alig->sequences = new std::string[alig->numberOfSequences];
 
     /* Skip first line */
-    line = utils::readLine(file);
+    line = utils::readLine(file, buffer);
 
     /* Skip lines until first sequence name is found */
     while(!file.eof()) {
 
-        /* Destroy previously allocated memory */
-        delete [] line;
-
         /* Read a new line in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -207,15 +195,14 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
 
         /* Skip blank lines */
         if (line == nullptr) {
-            line = utils::readLine(file);
+            line = utils::readLine(file, buffer);
             continue;
         }
 
         /* Skip lines with comments */
         if (!strncmp(line, "!", 1)) {
-            /* Deallocate memory and read a new line */
-            delete [] line;
-            line = utils::readLine(file);
+            /* Read a new line */
+            line = utils::readLine(file, buffer);
             continue;
         }
 
@@ -224,10 +211,8 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
 
         /* Skip lines with only comments */
         if (frag == nullptr) {
-
-            /* Deallocate memory and read a new line */
-            delete [] line;
-            line = utils::readLine(file);
+            /* Read a new line */
+            line = utils::readLine(file, buffer);
             continue;
         }
 
@@ -250,14 +235,9 @@ Alignment* mega_sequential_state::LoadAlignment(std::istream &file)
         /* Deallocate dynamic memory */
         delete [] frag;
 
-        delete [] line;
-
         /* Read a new line in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     }
-
-    /* Deallocate dynamic memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/nexus_m10_state.cpp
+++ b/source/FormatHandling/nexus_m10_state.cpp
@@ -37,7 +37,7 @@ int nexus_m10_state::CheckAlignment(std::istream *origin) {
     return 0;
 }
 
-Alignment *nexus_m10_state::LoadAlignment(const std::string &filename) {
+Alignment *nexus_m10_state::LoadAlignment(std::istream &file) {
     return nullptr;
 }
 

--- a/source/FormatHandling/nexus_state.cpp
+++ b/source/FormatHandling/nexus_state.cpp
@@ -66,24 +66,12 @@ int nexus_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* nexus_state::LoadAlignment(const std::string &filename)
+Alignment* nexus_state::LoadAlignment(std::istream& file)
 {
     Alignment* alig = new Alignment();
     /* NEXUS file format parser */
     char *frag = nullptr, *str = nullptr, *line = nullptr;
     int i, pos, state, firstBlock;
-    std::ifstream file;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Store input file name for posterior uses in other formats */
-    /* We store the file name */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     state = false;
     do {
@@ -199,9 +187,6 @@ Alignment* nexus_state::LoadAlignment(const std::string &filename)
 
     /* Deallocate memory */
     delete [] line;
-
-    /* Close the input file */
-    file.close();
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/nexus_state.cpp
+++ b/source/FormatHandling/nexus_state.cpp
@@ -39,16 +39,16 @@ int nexus_state::CheckAlignment(std::istream* origin)
     origin->seekg(0);
     origin->clear();
     char *firstWord = nullptr, *line = nullptr;
+    std::string buffer;
     
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
     if (origin->eof())
     {
-        delete [] line;
         return false;
     }
 
@@ -58,11 +58,9 @@ int nexus_state::CheckAlignment(std::istream* origin)
     /* Clustal Format */
     if((!strcmp(firstWord, "#NEXUS")) || (!strcmp(firstWord, "#nexus")))
     {
-        delete[] line;
         return 1;
     }
 
-    delete[] line;
     return 0;
 }
 
@@ -72,15 +70,13 @@ Alignment* nexus_state::LoadAlignment(std::istream& file)
     /* NEXUS file format parser */
     char *frag = nullptr, *str = nullptr, *line = nullptr;
     int i, pos, state, firstBlock;
+    std::string buffer;
 
     state = false;
     do {
 
-        /* Destroy previous assigned memory */
-        delete [] line;
-
         /* Read line in a safer way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -135,11 +131,9 @@ Alignment* nexus_state::LoadAlignment(std::istream& file)
     firstBlock = true;
 
     while(!file.eof()) {
-        /* Destroy previous assigned memory */
-        delete [] line;
 
         /* Read line in a safer way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -184,9 +178,6 @@ Alignment* nexus_state::LoadAlignment(std::istream& file)
         if (not pos)
             firstBlock = false;
     }
-
-    /* Deallocate memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/phylip32_m10_state.cpp
+++ b/source/FormatHandling/phylip32_m10_state.cpp
@@ -39,7 +39,7 @@ int phylip32_m10_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip32_m10_state::LoadAlignment(const std::string &filename)
+Alignment* phylip32_m10_state::LoadAlignment(std::istream &file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/phylip32_state.cpp
+++ b/source/FormatHandling/phylip32_state.cpp
@@ -128,24 +128,13 @@ int phylip32_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip32_state::LoadAlignment(const std::string &filename)
+Alignment* phylip32_state::LoadAlignment(std::istream& file)
 {
     /* PHYLIP 3.2 (Interleaved) file format parser */
     Alignment* alig = new Alignment();
     
     int i, blocksFirstLine, firstLine = true;
     char *str, *line = nullptr;
-    std::ifstream file;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Store the file name for futher format conversion*/
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     /* Read first valid line in a safer way */
     do {
@@ -235,8 +224,7 @@ Alignment* phylip32_state::LoadAlignment(const std::string &filename)
         }
     } while(!file.eof());
 
-    /* Close the input file and delete dinamic memory */
-    file.close();
+    /* Delete dynamic memory */
     delete [] line;
 
     /* Check the matrix's content */

--- a/source/FormatHandling/phylip32_state.cpp
+++ b/source/FormatHandling/phylip32_state.cpp
@@ -40,17 +40,16 @@ int phylip32_state::CheckAlignment(std::istream* origin)
     origin->clear();
     char *firstWord = nullptr, *line = nullptr;
     int blocks = 0;
-    std::string nline;
+    std::string buffer;
     
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
     if (origin->eof())
     {
-        delete [] line;
         return false;
     }
 
@@ -69,7 +68,6 @@ int phylip32_state::CheckAlignment(std::istream* origin)
             residNumber = atoi(firstWord);
         else 
         {
-            delete [] line;
             return false;
         }
 
@@ -77,7 +75,6 @@ int phylip32_state::CheckAlignment(std::istream* origin)
          * it is impossible to determine exactly which phylip format is */
         if((sequenNumber == 1) && (residNumber != 0))
         {
-            delete [] line;
             return false;
         }
 
@@ -87,9 +84,8 @@ int phylip32_state::CheckAlignment(std::istream* origin)
             blocks = 0;
 
             /* Read line in a safer way */
-            delete [] line;
             do {
-                line = utils::readLine(*origin);
+                line = utils::readLine(*origin, buffer);
             } while ((line == nullptr) && (!origin->eof()));
 
             /* If the file end is reached without a valid line, warn about it */
@@ -102,10 +98,9 @@ int phylip32_state::CheckAlignment(std::istream* origin)
                 firstWord = strtok(nullptr, DELIMITERS);
             }
 
-            delete [] line;
             /* Read line in a safer way */
             do {
-                line = utils::readLine(*origin);
+                line = utils::readLine(*origin, buffer);
             } while ((line == nullptr) && (!origin->eof()));
 
             firstWord = strtok(line, DELIMITERS);
@@ -113,7 +108,6 @@ int phylip32_state::CheckAlignment(std::istream* origin)
                 blocks--;
                 firstWord = strtok(nullptr, DELIMITERS);
             }
-            delete [] line;
             /* If the file end is reached without a valid line, warn about it */
             if (origin->eof())
             {
@@ -124,7 +118,6 @@ int phylip32_state::CheckAlignment(std::istream* origin)
             return (!blocks) ? 0 : 1;
         }
     }
-    delete[] line;
     return 0;
 }
 
@@ -135,10 +128,11 @@ Alignment* phylip32_state::LoadAlignment(std::istream& file)
     
     int i, blocksFirstLine, firstLine = true;
     char *str, *line = nullptr;
+    std::string buffer;
 
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     } while ((line == nullptr) && (!file.eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -172,9 +166,8 @@ Alignment* phylip32_state::LoadAlignment(std::istream& file)
 
     do {
         /* Read lines in a safer way. Destroy previous stored information */
-        delete [] line;
 
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         /* If there is nothing in the input line, skip the loop instructions */
         if(line == nullptr)
             continue;
@@ -223,9 +216,6 @@ Alignment* phylip32_state::LoadAlignment(std::istream& file)
             i++;
         }
     } while(!file.eof());
-
-    /* Delete dynamic memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/phylip40_m10_state.cpp
+++ b/source/FormatHandling/phylip40_m10_state.cpp
@@ -38,7 +38,7 @@ int phylip40_m10_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip40_m10_state::LoadAlignment(const std::string &filename)
+Alignment* phylip40_m10_state::LoadAlignment(std::istream& file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/phylip40_state.cpp
+++ b/source/FormatHandling/phylip40_state.cpp
@@ -127,23 +127,12 @@ int phylip40_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip40_state::LoadAlignment(const std::string &filename)
+Alignment* phylip40_state::LoadAlignment(std::istream &file)
 {
     /* PHYLIP/PHYLIP 4 (Sequential) file format parser */
     Alignment * alig = new Alignment();
     char *str, *line = nullptr;
-    std::ifstream file;
     int i;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if(!utils::checkFile(file))
-        return nullptr;
-
-    /* Store some data about filename for possible uses in other formats */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     /* Read first valid line in a safer way */
     do {
@@ -224,8 +213,7 @@ Alignment* phylip40_state::LoadAlignment(const std::string &filename)
         }
     }
 
-    /* Close the input file and delete dinamic memory */
-    file.close();
+    /* Delete dynamic memory */
     delete [] line;
 
     /* Check the matrix's content */

--- a/source/FormatHandling/phylip40_state.cpp
+++ b/source/FormatHandling/phylip40_state.cpp
@@ -40,11 +40,11 @@ int phylip40_state::CheckAlignment(std::istream* origin)
     origin->clear();
     char *firstWord = nullptr, *line = nullptr;
     int blocks = 0;
-    std::string nline;
+    std::string buffer;
     
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(*origin);
+        line = utils::readLine(*origin, buffer);
     } while ((line == nullptr) && (!origin->eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -65,7 +65,6 @@ int phylip40_state::CheckAlignment(std::istream* origin)
         if(firstWord != nullptr)
             residNumber = atoi(firstWord);
         else {
-            delete [] line;
             return false;
         }
 
@@ -73,7 +72,6 @@ int phylip40_state::CheckAlignment(std::istream* origin)
          * it is impossible to determine exactly which phylip format is */
         if((sequenNumber == 1) && (residNumber != 0))
             {
-            delete [] line;
             return true;
         }
 
@@ -84,14 +82,12 @@ int phylip40_state::CheckAlignment(std::istream* origin)
 
             /* Read line in a safer way */
             do {
-                delete [] line;
-                line = utils::readLine(*origin);
+                line = utils::readLine(*origin, buffer);
             } while ((line == nullptr) && (!origin->eof()));
 
             /* If the file end is reached without a valid line, warn about it */
             if (origin->eof())
                 {
-                delete [] line;
                 return false;
             }
 
@@ -103,8 +99,7 @@ int phylip40_state::CheckAlignment(std::istream* origin)
 
             /* Read line in a safer way */
             do {
-                delete [] line;
-                line = utils::readLine(*origin);
+                line = utils::readLine(*origin, buffer);
             } while ((line == nullptr) && (!origin->eof()));
 
             firstWord = strtok(line, DELIMITERS);
@@ -112,8 +107,6 @@ int phylip40_state::CheckAlignment(std::istream* origin)
                 blocks--;
                 firstWord = strtok(nullptr, DELIMITERS);
             }
-            
-            delete [] line;
             
             /* If the file end is reached without a valid line, warn about it */
             if (origin->eof())
@@ -123,7 +116,6 @@ int phylip40_state::CheckAlignment(std::istream* origin)
             return (!blocks) ? 1 : 0;
         }
     }
-    delete[] line;
     return 0;
 }
 
@@ -133,10 +125,11 @@ Alignment* phylip40_state::LoadAlignment(std::istream &file)
     Alignment * alig = new Alignment();
     char *str, *line = nullptr;
     int i;
+    std::string buffer;
 
     /* Read first valid line in a safer way */
     do {
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
     } while ((line == nullptr) && (!file.eof()));
 
     /* If the file end is reached without a valid line, warn about it */
@@ -167,9 +160,8 @@ Alignment* phylip40_state::LoadAlignment(std::istream &file)
     i = 0;
     while((i < alig->numberOfSequences) && (!file.eof())){
 
-        /* Read lines in a safer way. Destroy previous stored information */
-        delete [] line;
-        line = utils::readLine(file);
+        /* Read lines in a safer way. */
+        line = utils::readLine(file, buffer);
 
         /* It the input line/s are blank lines, skip the loop iteration  */
         if(line == nullptr)
@@ -194,10 +186,8 @@ Alignment* phylip40_state::LoadAlignment(std::istream &file)
         /* Try to get for each sequences its corresponding residues */
         i = 0;
         while((i < alig->numberOfSequences) && (!file.eof())) {
-            /* Read lines in a safer way. Destroy previous stored information */
-            delete [] line;
-
-            line = utils::readLine(file);
+            /* Read lines in a safer way. */
+            line = utils::readLine(file, buffer);
             /* It the input line/s are blank lines, skip the loop iteration  */
             if(line == nullptr)
                 continue;
@@ -212,9 +202,6 @@ Alignment* phylip40_state::LoadAlignment(std::istream &file)
             i++;
         }
     }
-
-    /* Delete dynamic memory */
-    delete [] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/phylip_paml_m10_state.cpp
+++ b/source/FormatHandling/phylip_paml_m10_state.cpp
@@ -38,7 +38,7 @@ int phylip_paml_m10_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip_paml_m10_state::LoadAlignment(const std::string &filename)
+Alignment* phylip_paml_m10_state::LoadAlignment(std::istream &file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/phylip_paml_state.cpp
+++ b/source/FormatHandling/phylip_paml_state.cpp
@@ -40,7 +40,7 @@ int phylip_paml_state::CheckAlignment(std::istream* origin)
     return 0;
 }
 
-Alignment* phylip_paml_state::LoadAlignment(const std::string &filename)
+Alignment* phylip_paml_state::LoadAlignment(std::istream &file)
 {
     return nullptr;
 }

--- a/source/FormatHandling/pir_state.cpp
+++ b/source/FormatHandling/pir_state.cpp
@@ -44,11 +44,9 @@ int pir_state::CheckAlignment(std::istream *origin) {
         if (line[0] == '>')
             if (line[3] == ';')
             {
-                // delete [] line;
                 return 2;
             }
     }
-    // delete[] line;
     return 0;
 }
 
@@ -65,11 +63,6 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
     /* Compute how many sequences are in the input alignment */
     alig->numberOfSequences = 0;
     while (!file.eof()) {
-
-        /* Deallocate previously used dinamic memory */
-        // if (line != nullptr)
-            // delete[] line;
-
         /* Read lines in a safe way */
         line = utils::readLine(file, buffer);
         if (line == nullptr)
@@ -101,10 +94,6 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
 
     /* Read the entire input file */
     while (!file.eof()) {
-
-        /* Deallocate local memory */
-        // delete[] line;
-
         /* Read lines in a safe way */
         line = utils::readLine(file, buffer);
         if (line == nullptr)
@@ -153,9 +142,6 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
             }
         }
     }
-
-    /* Deallocate dinamic memory */
-    // delete[] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/pir_state.cpp
+++ b/source/FormatHandling/pir_state.cpp
@@ -36,18 +36,19 @@
 namespace FormatHandling {
 int pir_state::CheckAlignment(std::istream *origin) {
     char *line;
+    std::string buffer;
     origin->seekg(0);
-    line = utils::readLine(*origin);
+    line = utils::readLine(*origin, buffer);
     if (line == nullptr) return 0;
     if (strlen(line) > 4) {
         if (line[0] == '>')
             if (line[3] == ';')
             {
-                delete [] line;
+                // delete [] line;
                 return 2;
             }
     }
-    delete[] line;
+    // delete[] line;
     return 0;
 }
 
@@ -59,17 +60,18 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
     bool seqIdLine, seqLines;
     char *str, *line = nullptr;
     int i;
+    std::string buffer;
 
     /* Compute how many sequences are in the input alignment */
     alig->numberOfSequences = 0;
     while (!file.eof()) {
 
         /* Deallocate previously used dinamic memory */
-        if (line != nullptr)
-            delete[] line;
+        // if (line != nullptr)
+            // delete[] line;
 
         /* Read lines in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -101,10 +103,10 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
     while (!file.eof()) {
 
         /* Deallocate local memory */
-        delete[] line;
+        // delete[] line;
 
         /* Read lines in a safe way */
-        line = utils::readLine(file);
+        line = utils::readLine(file, buffer);
         if (line == nullptr)
             continue;
 
@@ -153,7 +155,7 @@ Alignment *pir_state::LoadAlignment(std::istream &file) {
     }
 
     /* Deallocate dinamic memory */
-    delete[] line;
+    // delete[] line;
 
     /* Check the matrix's content */
     alig->fillMatrices(true);

--- a/source/FormatHandling/pir_state.cpp
+++ b/source/FormatHandling/pir_state.cpp
@@ -51,25 +51,14 @@ int pir_state::CheckAlignment(std::istream *origin) {
     return 0;
 }
 
-Alignment *pir_state::LoadAlignment(const std::string &filename) {
+Alignment *pir_state::LoadAlignment(std::istream &file) {
     /* NBRF/PIR file format parser */
 
     Alignment *alig = new Alignment();
 
     bool seqIdLine, seqLines;
     char *str, *line = nullptr;
-    std::ifstream file;
     int i;
-
-    /* Check the file and its content */
-    file.open(filename, std::ifstream::in);
-    if (!utils::checkFile(file))
-        return nullptr;
-
-    /* Store input file name for posterior uses in other formats */
-    // alig->filename.append("!Title ");
-    alig->filename.append(filename);
-    alig->filename.append(";");
 
     /* Compute how many sequences are in the input alignment */
     alig->numberOfSequences = 0;
@@ -162,8 +151,6 @@ Alignment *pir_state::LoadAlignment(const std::string &filename) {
             }
         }
     }
-    /* Close the input file */
-    file.close();
 
     /* Deallocate dinamic memory */
     delete[] line;

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -301,48 +301,42 @@ namespace utils {
         return true;
     }
 
-    char *readLine(std::istream &file) {
+    char *readLine(std::istream &file, std::string &buffer) {
         // Read a new line from current input stream. This function is better than
         // standard one since cares of operative system compability. It is useful
         // as well because remove tabs and blank spaces at lines beginning/ending
 
         int state;
-        std::string nline;
         char *line = nullptr;
 
-        // Check it the end of the file has been reached or not
+        /* Check it the end of the file has been reached or not */
         if (file.eof())
             return nullptr;
 
+        /* Remove previous line from buffer, if any. */
+        buffer.clear();
 
-        /* Store first line found. For -Windows & MacOS compatibility- carriage return
-        * is considered as well as a new line character */
-        //    for( ; (c != '\n') && (c != '\r') && ((!file.eof())); file.read(&c, 1))
-        //        nline.resize(nline.size() + 1, c);
-        getline(file, nline);
+        /* Store next line into the buffer. */
+        getline(file, buffer);
+
         /* Remove blank spaces & tabs from the beginning of the line */
+        int begin = (int) buffer.find_first_not_of(" \t");
+        int end = (int) buffer.find_last_not_of(" \t");
+        int length = end - begin + 1;
 
-        state = nline.find(' ', 0);
-        while (state != (int) std::string::npos && state == 0) {
-            nline.erase(state, 1);
-            state = nline.find(' ', state);
+        /* If there is nothing to return, give back a nullptr pointer */
+        if (begin == (int) std::string::npos || length == 0)
+            return nullptr; 
+
+        /* Add the NUL-bytes sentinel to the end of the line. */
+        if (begin + length >= buffer.size()) {
+            buffer.push_back('\0');
+        } else {
+            buffer[begin + length] = 0;
         }
 
-        state = nline.find('\t', 0);
-        while (state != (int) std::string::npos && state == 0) {
-            nline.erase(state, 1);
-            state = nline.find('\t', state);
-        }
-
-        // If there is nothing to return, give back a nullptr pointer ...
-        if (nline.empty())
-            return nullptr;
-
-        // Otherwise, initialize the appropiate data structure,
-        // dump the data and return it
-        line = new char[nline.size() + 1];
-        strcpy(line, &nline[0]);
-        return line;
+        /* Return a view over a region of the buffer to avoid a copy. */
+        return &buffer[begin];
     }
 
     char *trimLine(std::string nline) {

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -301,50 +301,6 @@ namespace utils {
         return true;
     }
 
-    char *readLine(std::ifstream &file) {
-        StartTiming("char* readLine(std::ifstream &file) ");
-        // Read a new line from current input stream. This function is better than
-        // standard one since cares of operative system compability. It is useful
-        // as well because remove tabs and blank spaces at lines beginning/ending 
-
-        int state;
-        std::string nline;
-        char *line = nullptr;
-
-        // Check it the end of the file has been reached or not
-        if (file.eof())
-            return nullptr;
-
-        /* Store first line found. For -Windows & MacOS compatibility- carriage return
-        * is considered as well as a new line character */
-        //    for( ; (c != '\n') && (c != '\r') && ((!file.eof())); file.read(&c, 1))
-        //        nline.resize(nline.size() + 1, c);
-        getline(file, nline);
-
-        // Remove blank spaces & tabs from the beginning of the line
-        state = nline.find(' ', 0);
-        while (state != (int) std::string::npos && state == 0) {
-            nline.erase(state, 1);
-            state = nline.find(' ', state);
-        }
-
-        state = nline.find('\t', 0);
-        while (state != (int) std::string::npos && state == 0) {
-            nline.erase(state, 1);
-            state = nline.find('\t', state);
-        }
-
-        /* If there is nothing to return, give back a nullptr pointer ... */
-        if (nline.empty())
-            return nullptr;
-
-        // Otherwise, initialize the appropiate data structure,
-        // dump the data and return it 
-        line = new char[nline.size() + 1];
-        strcpy(line, nline.c_str());
-        return line;
-    }
-
     char *readLine(std::istream &file) {
         // Read a new line from current input stream. This function is better than
         // standard one since cares of operative system compability. It is useful


### PR DESCRIPTION
Hi again!

This PR refactors the code and interface of the alignment loading in the I/O handlers:

## 1. A more generic interface for format handlers

I added a `BaseFormatHandler::LoadAlignment(std::istream&)` method to all format handlers, which takes care of parsing the file content without opening/closing the file. The original `BaseFormatHandler::LoadAlignment(std::string &filename)` is still supported but simply takes care of opening and checking the file before passing it to the other method.

This also allowed to refactor some common code for handling files between all the different handlers straight into the `BaseFormatHandler` base method implementation.

This is something that's needed in Pytrimal so I can use the parser implementations with a Python file-like objects that may be provided by the user and not necessarily corresponds to a file opened somewhere on the local filesystem.

## 2. A rewrite of the `readLine` util and calling methods.

The way `readLine` was currently implemented has three problems:
1. It has no way to reuse memory used internally in the `getline` call, so a new buffer needs to be allocated every time.
2. Its use of `string::erase` one character at a time to remove leading whitespaces is very inefficient (which is probably not so bad in most of the cases because leading whitespaces are rare, but they may happen).
3. It allocates a new line on every call, which will be deallocated later instead of being recycled.

This is unfortunate because this method is called in hot loops of all parsers, and since parsers are likely to read more than one line per alignment there is room to reuse buffers. When I profiled the FASTA reader on `example.015.AA.bctoNOG.ENOG41099F3.fasta`, it showed that `malloc` was called 975,152 times:
![image](https://github.com/inab/trimal/assets/8660647/24b925c1-fdae-4419-80ab-44dc57314e83)

To address this, I changed `readLine` so that:

- It takes a `string` buffer as a second argument. It will clear the buffer (with `string::clear`), and then use it to call `getline`. The cleared strings typically does not need to reallocate before receiving its new content. 
- [`std::string::find_first_not_of`](https://cplusplus.com/reference/string/string/find_first_not_of/) and [`std::string::find_last_not_of`](https://cplusplus.com/reference/string/string/find_last_not_of/) allows trimming the line without actually copying data. 
- The return pointer points to the provided buffer rather than a new copy, so the caller doesn't need to free any memory. The pointer is invalidated on the next call or when `buffer` is modified.
 
These changes lead to **way** less deallocation/reallocations since the string buffer memory is recycled and one unneeded copy is eliminated.  In addition most memory management is done by the buffer directly: this removes many instances of manual deallocation in the code of all parsers, because the deallocation just happens when the buffer goes out of scope. 

Using the same file as before, `malloc` is now called only 16,665 times:
![image](https://github.com/inab/trimal/assets/8660647/c1c48b5d-2ae7-423c-a1ce-eae3badca009)

This is not really performance critical but I figured I'd give it a shot while updating the I/O code, it also simplifies the code in several format handlers. The actual performance effect depends heavily on the `malloc` on the host machine but usually the less time is spend outside of the allocator, the better :smile: 




