### PR TITLE
Fix potential memory leak

### DIFF
--- a/source/alignment.cpp
+++ b/source/alignment.cpp
@@ -1636,9 +1636,9 @@ alignment *alignment::getTranslationCDS(int newResidues, int newSequences, int *
   /* ***** ***** ***** ***** ***** ***** ***** ***** */
   /* Deallocated auxiliar memory */
   delete [] matrixAux;
-  delete mappedSeqs;
-  delete tmpSequence;
-  delete selectedRes;
+  delete [] mappedSeqs;
+  delete [] tmpSequence;
+  delete [] selectedRes;
   /* ***** ***** ***** ***** ***** ***** ***** ***** */
 
   /* ***** ***** ***** ***** ***** ***** ***** ***** */


### PR DESCRIPTION
This commit fixes these g++ warning messages:
```
g++ -Wall -O2  -c compareFiles.cpp
alignment.cpp: In member function ‘alignment* alignment::getTranslationCDS(int, int, int*, std::string*, sequencesMatrix*, alignment*)’:
alignment.cpp:1639:10: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
 1639 |   delete mappedSeqs;
      |          ^~~~~~~~~~
alignment.cpp:1559:36: note: returned from ‘void* operator new [](std::size_t)’
 1559 |   mappedSeqs = new int[newSequences];
      |                                    ^
alignment.cpp:1640:10: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
 1640 |   delete tmpSequence;
      |          ^~~~~~~~~~~
alignment.cpp:1591:36: note: returned from ‘void* operator new [](std::size_t)’
 1591 |   tmpSequence = new int[oldResidues];
      |                                    ^
alignment.cpp:1641:10: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
 1641 |   delete selectedRes;
      |          ^~~~~~~~~~~
alignment.cpp:1572:36: note: returned from ‘void* operator new [](std::size_t)’
 1572 |   selectedRes = new int[oldResidues];
```
