### PR TITLE
GitHub Actions: Upgrade uraimo/run-on-arch-action to v3 and Ubuntu to v22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
-          distro: 22.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --volume "${PWD}:/trimal" 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ name: Build
 
 jobs:
   download_and_test_ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Download Release Binaries
@@ -26,7 +26,7 @@ jobs:
           ./scripts/compare_trimmed_msas.sh
           
   build_and_test_ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [x86_64, aarch64]
@@ -43,7 +43,7 @@ jobs:
         uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
-          distro: ubuntu20.04
+          distro: 22.04
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --volume "${PWD}:/trimal" 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build trimal for Linux aarch64
         if: matrix.arch == 'aarch64'
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04


### PR DESCRIPTION
https://github.com/uraimo/run-on-arch-action

Alternatively, you could run on [`ubuntu-22.04-arm`](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md) or [`ubuntu-24.04-arm`](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-24-image.md).
* https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories