### PR TITLE
Split tests on release-run and build-run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 on:
   push:
     paths:
+        - '.github/workflows/build.yml'
         - 'dataset/**'
         - 'scripts/**'
         - 'source/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,15 @@
 on:
   push:
+    branches:
+      - trimAl
     paths:
-        - '.github/workflows/build.yml'
-        - 'dataset/**'
-        - 'scripts/**'
-        - 'source/**'
+      - '.github/workflows/build.yml'
+      - 'dataset/**'
+      - 'scripts/**'
+      - 'source/**'
   pull_request:
+    branches:
+      - trimAl
     paths:
       - '.github/workflows/build.yml'
       - 'dataset/**'


### PR DESCRIPTION
Run workflow with binaries only when changes on release and separate jobs for download of release binaries, build of repository source code and run of tests.