### PR TITLE
Fix `-clusters` options from the CLI

### DIFF
--- a/include/trimalManager.h
+++ b/include/trimalManager.h
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstring>
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <functional>

--- a/source/Cleaner.cpp
+++ b/source/Cleaner.cpp
@@ -27,6 +27,8 @@
 
 ***************************************************************************** */
 
+#include <cassert>
+
 #include "Alignment/Alignment.h"
 #include "Statistics/Similarity.h"
 #include "Statistics/Consistency.h"
@@ -1045,7 +1047,7 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
     // Compute the maximum, the minimum and the average
     // identity values from the sequences
     arrayIdentityPosition = 0;
-    for (i = 0, gMax = 0, gMin = 1, startingPoint = 0; i < alig->originalNumberOfSequences; i++) {
+    for (i = 0, gMax = 0, gMin = 1, startingPoint = 0, avg = 0; i < alig->originalNumberOfSequences; i++) {
         comparedSequences = 0;
         if (alig->saveSequences[i] == -1) continue;
 
@@ -1059,13 +1061,15 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
             comparedSequences++;
         }
 
-        startingPoint += avg / comparedSequences;
-        gMax = std::max(gMax, max);
-        gMin = std::min(gMin, min);
-
+        if (comparedSequences > 0) {
+            startingPoint += avg / comparedSequences;
+            gMax = std::max(gMax, max);
+            gMin = std::min(gMin, min);
+        }
     }
     // Take the starting point as the average value
-    startingPoint /= arrayIdentityPosition;
+    if (arrayIdentityPosition > 0)
+        startingPoint /= arrayIdentityPosition;
 
     // Compute and sort the sequence length
     seqs = new int *[alig->numberOfSequences];

--- a/source/Cleaner.cpp
+++ b/source/Cleaner.cpp
@@ -1051,7 +1051,7 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
         comparedSequences = 0;
         if (alig->saveSequences[i] == -1) continue;
 
-        for (j = i + 1; j < alig->numberOfSequences; j++) {
+        for (j = i + 1, min = 1, max = 0; j < alig->numberOfSequences; j++) {
             if (alig->saveSequences[j] == -1) continue;
 
             max = std::max(max, identities[arrayIdentityPosition]);
@@ -1068,8 +1068,7 @@ float Cleaner::getCutPointClusters(int clusterNumber) {
         }
     }
     // Take the starting point as the average value
-    if (arrayIdentityPosition > 0)
-        startingPoint /= arrayIdentityPosition;
+    if (arrayIdentityPosition > 0) startingPoint /= arrayIdentityPosition;
 
     // Compute and sort the sequence length
     seqs = new int *[alig->numberOfSequences];

--- a/source/FormatHandling/BaseFormatHandler.cpp
+++ b/source/FormatHandling/BaseFormatHandler.cpp
@@ -28,6 +28,7 @@
 ***************************************************************************** */
 
 #include <limits>
+#include <cstdint>
 
 #include <FormatHandling/FormatManager.h>
 #include "FormatHandling/FormatManager.h"


### PR DESCRIPTION
Hi!

As reported by @vagkaratzas in https://github.com/althonos/pytrimal/issues/5 it seems that the `-clusters` issue from the CLI doesn't work as expected, as even example runs seem to always return the full alignment rather than the cluster representatives.

Digging a bit into this, I noticed that the `Cleaner::getCutPointClusters` was returning `+inf` as the identity cut point, which was causing all sequences to be selected. In several places of the function code, variables were not properly initialized and/or reinitialized, which was causing inconsistent behavior across executions, followed by a division-by-zero which was causing `+inf` to be returned. 

I fixed the `Cleaner::getCutPointClusters` code so that now the `-clusters` option works as expected. In addition, I added some missing `#include` statements which were preventing the project from compiling with GCC 15.2.1, at least on my machine.